### PR TITLE
Renamed relNotes to release_notes (closes #7)

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@ a:not(href){ color: red }
     }
   },
   "fullscreen": "true",
-  "relNotes": {
+  "release_notes": {
     "1.0": "Bugs fixed. New exciting effects. Ready for an official release!",
     "0.5": "First alpha version with still some bugs but already fun!"
   }
@@ -800,10 +800,10 @@ a:not(href){ color: red }
       </section>
       <section>
         <h3>
-          <code title="">relNotes</code> member
+          <code title="">release_notes</code> member
         </h3>
         <p>
-          The <dfn id='propdef-relnotes'>relNotes</dfn> <a>localizable
+          The <dfn id='propdef-relnotes'>release_notes</dfn> <a>localizable
           member</a> is a <a>release notes object</a> that represents a change
           history for the application from one version to another.
         </p>


### PR DESCRIPTION
As all other members are using fully expanded form and an underscore, I've renamed the member "release_notes".
