### PR TITLE
Fix a bug that caused ReSpec to load two invalid resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -1224,9 +1224,6 @@ installButton.addEventListener("click", function(e){
         permitted by the license of that specification. The [[!HTML]]
         specification is edited by Ian Hickson.
       </p>
-    </section><!-- override Respec style on purpose! -->
-    <style>
-@import 'http://www.w3.org/StyleSheets/TR/W3C-WD';
-    </style>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
Fix a bug that caused ReSpec to load two invalid resources:

http://www.w3.org/StyleSheets/TR/-WD
http://www.w3.org/StyleSheets/TR/

(at-import blocks other resource from being loaded in parallel, which
apparantly caused a bug with ReSpec.)
