### PR TITLE
Typos and confusing points

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,7 +514,7 @@ installButton.addEventListener("click", function(e){
             implemented the "orientation" descriptor. It also lacks definitions
             for "-primary" and "-secondary" contraints, which are important for
             various applications, and doesn't currently allow providing
-            multiple allowed orientations - hopefully the CSS Device Adaption
+            multiple allowed orientations - hopefully the CSS Device Adaptation
             spec can align with the Screen Orientation spec.
           </p>
         </div>
@@ -533,7 +533,7 @@ installButton.addEventListener("click", function(e){
           "bookmark".
         </p>
         <p>
-          The <dfn>mode of operation</dfn> in which a web application can be
+          The <dfn>modes of operation</dfn> in which a web application can be
           launched include:
         </p>
         <dl>
@@ -555,7 +555,7 @@ installButton.addEventListener("click", function(e){
           </dd>
         </dl>
         <p>
-          Standalone mode can also be displayed in the following view modes:
+          Standalone mode can also be displayed in the following view modes:(?)
         </p>
         <p>
           A <dfn>valid application mode</dfn> is one that conforms to the
@@ -595,7 +595,7 @@ installButton.addEventListener("click", function(e){
         <p>
           The <dfn>steps for fetching a manifest</dfn> are given by the
           following algorithm. It takes a <var>url</var> URL as an argument. It
-          returns a response (which may be in error).
+          returns a response (which may be an error).
         </p>
         <ol>
           <li>Let <var>response</var> be the result of <a href=
@@ -765,7 +765,7 @@ installButton.addEventListener("click", function(e){
           whatever step or sub-step caused the condition.
         </p>
         <p>
-          To obtain a manifest, as user agent MUST:
+          To obtain a manifest, a user agent MUST:
         </p>
         <ol>
           <li>If the <code>link</code> element lacks a href attribute, abort
@@ -846,7 +846,7 @@ installButton.addEventListener("click", function(e){
         <p>
           The <dfn>steps for processing a dimension of an icon</dfn> are given
           by the following algorithm. The algorithm takes an <var>icon</var>
-          and a <var>key</var> ('width" or "height") as an argument. The
+          and a <var>key</var> ("width" or "height") as an argument. The
           algorithm returns a positive number, <code>undefined</code>, or an
           error.
         </p>
@@ -905,12 +905,12 @@ installButton.addEventListener("click", function(e){
         <p>
           The <dfn title="icon-type">type</dfn> member of an icon is a hint as
           to the media type of the icon. The purpose of this member is to allow
-          a user agent can ignore icons of media types it does not support.
+          a user agent to ignore icons of media types it does not support.
         </p>
         <p>
           The <dfn>steps for processing the <code>type</code> member of an
           icon</dfn> are given by the following algorithm. The algorithm takes
-          an <var>icon</var> object as an argument, and returns either string
+          an <var>icon</var> object as an argument, and returns either a string. an error
           or <code>undefined</code>.
         </p>
         <ol>
@@ -945,7 +945,7 @@ installButton.addEventListener("click", function(e){
         <dd>
           The standalone attribute provides a means for a developer to check if
           the application is running in <a>standalone</a> mode. When getting,
-          the user agent MUST returns <code>true</code> if the application is
+          the user agent MUST return <code>true</code> if the application is
           running as <a>standalone</a>. Return <code>false</code> otherwise.
         </dd>
         <dt>
@@ -1076,7 +1076,7 @@ installButton.addEventListener("click", function(e){
         <p>
           If the protocol over which the manifest is transferred supports the
           [[!MIME-TYPES]] specification (e.g. HTTP), it is RECOMMENDED that the
-          manifest be labeled with the <a>media type for a manifests</a>.
+          manifest be labeled with the <a>media type for a manifest</a>.
         </p>
         <dl>
           <dt>


### PR DESCRIPTION
The numbers describe the lines the typos were found on, not the number of errors found.

517 - Adaption to Adaptation

536 - mode to modes

558 - is valid application mode a view mode?
Because that doesn't seem obvious to me and it doesn't really seem to list any other modes? Just confused by that part.

598 - in to an, I realize you could have meant in, just wanted to make sure.

768 - as to a (not sure if that's jargon I don't understand or if it really does need to be changed.)

849 - ' to "

908 - "can" to "to" (again, not sure if that MUST has meaning I'm not understanding? I even looked at the 
keywords file RFC2119, still not positive.)

913 - added "a" before "string" and the algorithm had a path that ended in error so I thought "an error" should be a result, too?

947-949 - "When getting" doesn't really make sense, though I guess I see what you're getting. returns to return (unless I'm not understanding more jargon.)

1079 - pretty sure that shouldn't be "a manifests" if you're finding the media type for a manifest, so changed to manifest. Also, "a manifests" doesn't make sense.
