### PR TITLE
Fix example to use manifest.json

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
 &lt;title&gt;Store finder - search&lt;/title&gt;
 
 &lt;!-- Startup configuration --&gt;
-&lt;link rel="manifest" href="add_to_homescreen.json"&gt;
+&lt;link rel="manifest" href="manifest.json"&gt;
 
 &lt;!-- Application metadata --&gt;
 &lt;meta name="application-name" content="Store Finder"&gt;


### PR DESCRIPTION
We probably want to push for good practices and having "add_to_homescreen.json" is a bit odd.
