### PR TITLE
Reporting the error SHOULD be done via a UA specific way.

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,9 +352,9 @@
         </p>
         <p>
           When instructed to <dfn>issue a developer warning</dfn>, the user
-          agent MAY report the conformance violation to the developer in a
+          agent SHOULD report the conformance violation to the developer in a
           user-agent-specific manner (e.g., report the problem in an error
-          console), or MAY ignore the error and do nothing.
+          console).
         </p>
         <p>
           When instructed to <dfn>ignore</dfn>, the user agent MUST act as if


### PR DESCRIPTION
Also, adding that "it MAY ignore" is not that useful given that SHOULD or MAY already implies that it is possible to ignore.

It think SHOULD is better here because unless the UA has a good reason, it should do it.
