### PR TITLE
Clarify the expected behaviour regarding <link rel='manifest'>

### DIFF
--- a/index.html
+++ b/index.html
@@ -870,13 +870,20 @@
           "hdw">erroneous</span>).
         </p>
         <p>
-          The user agent MUST ignore the <code>hreflang</code>,
-          <code>type</code> , <code>sizes</code> and <code>media</code>
-          attributes defined on the link element associated to a manifest.
+          The user agent MUST ignore the <code>media</code> attribute. This is a
+          willful violation of the [[!HTML]] specification.
+        </p>
+        <p>
+          The user agent MUST ignore the hint provided by the <code>type</code>
+          attribute.
         </p>
         <p>
           The user agent MUST NOT fire a <code>load</code> or <code>error</code>
           event on the link element.
+        </p>
+        <p>
+          The <code>sizes</code> and <code>hreflang</code> attributes do not
+          apply to the manifest and hence SHOULD be ignored.
         </p>
         <p>
           The appropriate time to <a href=


### PR DESCRIPTION
The fact that we ignore the media attribute isn't following the HTML specification but the HTML specification is already not following what's happening in the wild. We should let Hixie know but in the mean time, we want to make sure that implementers of this specification don't get it wrong.

There are still some open questions about the crossorigin argument and the load event.
