### PR TITLE
Fixed  `start_url` processing issues (closes #201)

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,7 +449,9 @@ Content-Type: application/manifest+json
           </li>
           <li>Let <var>start URL</var> be the result of running the <a>steps
           for processing the <code>start_url</code> member</a> with
-          <var>manifest URL</var>.
+          <var>manifest URL</var> and the URL of the <a href=
+          "http://www.whatwg.org/specs/web-apps/current-work/#top-level-browsing-context">
+            top-level browsing context</a>.
           </li>
           <li>Let <var>display mode</var> be the result of running the <a>steps
           for processing the <code>display</code> member</a> with
@@ -835,8 +837,12 @@ Content-Type: application/manifest+json
           The <dfn>steps for processing the <code>start_url</code> member</dfn>
           are given by the following algorithm. The algorithm takes a
           <a>manifest</a> <var>manifest</var> and a <a href=
-          "http://url.spec.whatwg.org/#concept-url">URL</a> <var>base
-          URL</var>. This algorithm returns a <a href=
+          "http://url.spec.whatwg.org/#concept-url">URL</a> <var>manifest
+          URL</var> and <a href=
+          "http://url.spec.whatwg.org/#concept-url">URL</a> <var>document
+          URL</var> (which is the URL of the <a href=
+          "http://www.whatwg.org/specs/web-apps/current-work/#top-level-browsing-context">
+          top-level browsing context</a>). This algorithm returns a <a href=
           "http://www.whatwg.org/specs/web-apps/current-work/#valid-url">valid
           URL</a>.
         </p>
@@ -847,20 +853,21 @@ Content-Type: application/manifest+json
           </li>
           <li>Let <var>type</var> be <a>Type</a>(<var>value</var>).
           </li>
-          <li>If <var>type</var> is not "string", then:
+          <li>If <var>type</var> is not "string" or <var>value</var> is the
+          empty string, then:
             <ol>
               <li>If <var>type</var> is not "<code>undefined</code>", issue a
               developer warning that the type is unsupported.
               </li>
-              <li>Return <var>base URL</var>.
+              <li>Return <var>document URL</var>.
               </li>
             </ol>
           </li>
           <li>Let <var>potential URL</var> be the result of <a href=
           "http://url.spec.whatwg.org/#parsing">parsing</a> <var>value</var>
-          using <var>base URL</var> as the base URL.
+          using <var>manifest URL</var> as the base URL.
           </li>
-          <li>If <var>potential URL</var> is failure, return <var>base
+          <li>If <var>potential URL</var> is failure, return <var>document
           URL</var>.
           </li>
           <li>Otherwise, return <var>potential URL</var>.
@@ -937,16 +944,16 @@ Content-Type: application/manifest+json
           "hdw">erroneous</span>).
         </p>
         <p>
-          The user agent MUST ignore the <code>media</code> attribute. This is a
-          willful violation of the [[!HTML]] specification.
+          The user agent MUST ignore the <code>media</code> attribute. This is
+          a willful violation of the [[!HTML]] specification.
         </p>
         <p>
           The user agent MUST ignore the hint provided by the <code>type</code>
           attribute.
         </p>
         <p>
-          The user agent MUST NOT fire a <code>load</code> or <code>error</code>
-          event on the link element.
+          The user agent MUST NOT fire a <code>load</code> or
+          <code>error</code> event on the link element.
         </p>
         <p>
           The <code>sizes</code> and <code>hreflang</code> attributes do not


### PR DESCRIPTION
- added document URL as arg to the algorithm.
- If the URL is the empty string or undefined, then it should return
  the URL of the top-level browsing context.
- If the URL is in error, it should return the URL of the top-level
  browsing context.
