### PR TITLE
Rewrite of fetching and processing (closes #17, #186, #188, #195, #198)

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,8 @@
         application's name, links to icons, as well as the preferred URL to
         open when a user launches the web application. The manifest also allows
         developers to declare a default orientation for their web application,
-        as well as how the application is to be displayed by the user agent
-        (e.g., in fullscreen).
+        as well as providing the ability to set the display mode for the
+        application (e.g., in fullscreen).
       </p>
       <p>
         Using this metadata, user agents can provide developers with means to
@@ -76,8 +76,8 @@
         discussions will find the specification changing out from under them in
         incompatible ways.</strong> Vendors interested in implementing this
         specification before it eventually reaches the Candidate Recommendation
-        phase should <a href="https://github.com/w3c/manifest">subscribe to the
-        repository on GitHub</a> and take part in the discussions.
+        phase should <a href="https://github.com/w3c/manifest/issues">subscribe
+        to the repository on GitHub</a> and take part in the discussions.
       </p>
     </section>
     <section class="informative">
@@ -202,7 +202,7 @@
         <a href=
         "http://www.whatwg.org/specs/web-apps/current-work/#top-level-browsing-context">
         top-level browsing context</a> (i.e., it is used as the display mode
-        for as the window is <a href=
+        when the window is <a href=
         "http://www.whatwg.org/specs/web-apps/current-work/#navigate">navigated</a>).
         The user agent MAY override the <a>default display mode</a> for
         security reasons (e.g., the <a href=
@@ -357,8 +357,8 @@
         </p>
         <div class="note">
           <p>
-            Note: The <a accesskey="">extension point</a> is to supposed to
-            help avoid <a href=
+            Note: The <a accesskey="">extension point</a> is meant to help
+            avoid <a href=
             "http://annevankesteren.nl/2014/02/monkey-patch">issues related to
             monkey patching</a>.
           </p>
@@ -416,44 +416,9 @@
           of running the <a>steps for processing the <code>name</code>
           member</a>.
           </li>
-          <li>If <var>name</var> is <code>undefined</code> or the empty string:
-            <ol>
-              <li>If <var>link</var> was passed as an argument, attempt to
-              derive the name of the Web application from the <var>link</var>
-              element's <a href=
-              "http://dom.spec.whatwg.org/#concept-node-document">node
-              document</a> and set <var>name</var> to be the result. For
-              example, [[!HTML]]'s <a href=
-              "http://www.whatwg.org/specs/web-apps/current-work/#meta-application-name">
-                application-name</a> or the <code><a href=
-                "http://www.whatwg.org/specs/web-apps/current-work/#the-title-element">
-                title</a></code> element can serve as suitable fallbacks.
-              </li>
-              <li>If no suitable <var>name</var> is found, then set
-              <var>name</var> to be an implementation specific string that can
-              serve as the name for the web application.
-              </li>
-            </ol>
-          </li>
           <li>Let <var>icons</var> of <var>parsed manifest</var> be the result
           of running the <a>steps for processing the <code>icons</code>
           member</a>.
-          </li>
-          <li>If <var>icons</var> is the empty list:
-            <ol>
-              <li>If <var>link</var> was passed as an argument, attempt to
-              derive the icons for the Web application from the <var>link</var>
-              element's <a href=
-              "http://dom.spec.whatwg.org/#concept-node-document">node
-              document</a>. For example, an <a href=
-              "http://www.whatwg.org/specs/web-apps/current-work/#rel-icon">icon
-              link type</a> and a <code>favicon.ico</code> can serve as
-              suitable fallbacks.
-              </li>
-              <li>If no suitable icons were found, an implementation specific
-              icon can serve as the icon for the web application.
-              </li>
-            </ol>
           </li>
           <li>Return <var>parsed manifest</var>.
           </li>
@@ -506,7 +471,13 @@
           "http://www.whatwg.org/specs/web-apps/current-work/#attr-meta-name">name</a>
           attribute is <a href=
           "http://www.whatwg.org/specs/web-apps/current-work/#meta-application-name">
-          <code>application-name</code></a> in a [[!HTML]] document.
+          <code>application-name</code></a> in a [[!HTML]] document. In cases
+          where no suitable name can be derived from processing a manifest,
+          [[!HTML]]'s <a href=
+          "http://www.whatwg.org/specs/web-apps/current-work/#meta-application-name">
+          application-name</a> or the <code><a href=
+          "http://www.whatwg.org/specs/web-apps/current-work/#the-title-element">
+          title</a></code> element serve as suitable fallbacks.
         </p>
         <p>
           The <dfn>steps for processing the name member</dfn> is given by the
@@ -547,15 +518,15 @@
           preferences.
         </p>
         <p class="note">
-          The icons in the manifest override any icons listed in the <a href=
+          If no icons are listed in the manifest (or none of them are found to
+          be suitable during processing), it is RECOMMENDED that the user agent
+          fall back to using any icons found in the <code>Document</code> of
+          the <a href=
           "http://www.whatwg.org/specs/web-apps/current-work/#top-level-browsing-context">
-          top-level browsing context</a>'s <code>Document</code>. However, if
-          no icons are listed in the manifest (or none of them are found to be
-          suitable during processing), the user agent will fall back to trying
-          to use any found in the <code>Document</code> of the<a href=
-          "http://www.whatwg.org/specs/web-apps/current-work/#top-level-browsing-context">top-level
-          browsing context</a>. This fall back behavior is enforced during the
-          <a>steps for processing a manifest</a> instead of in this section.
+          top-level browsing context</a>. For example, an <a href=
+          "http://www.whatwg.org/specs/web-apps/current-work/#rel-icon">icon
+          link type</a> and/or a <code>favicon.ico</code> can serve as suitable
+          fallbacks.
         </p>
         <p>
           The <dfn>steps for processing the <code>icons</code> member</dfn> are


### PR DESCRIPTION
- Formalizes using link element as the solution (closes #17)
- Banned media attribute. At least, we say that it's not considered
  during processing. (closes #186)
- Added text about when events need to be fired (closes #188)
- The fetch part of the specification now mentions the crossorigin
  attribute (closes #195)
- fixed copy/pasta error relating to icons/orientation (closes #198)
- fixed a whole bunch of editorial issues.
