### PR TITLE
Improve the organization of the spec, non-normative changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1678,8 +1678,9 @@ Content-Security-Policy: img-src icons.example.com;
           </h3>
           <p>
             Although proprietary extensions are undesirable, they can't
-            realistically be avoided. As such, the RECOMMENDED way to add a
-            proprietary extension is to use a vendor prefix.
+            realistically be avoided. As such, the RECOMMENDED way to add a new
+            proprietary manifest member as an extension is to use a vendor
+            prefix.
           </p>
           <p>
             The following is an example of two hypothetical vendor extensions.


### PR DESCRIPTION
@marcoscaceres @kenchris After being away from this spec for a while I started to address https://github.com/w3c/manifest/issues/234 and ended up moving a bunch of content around and embellish non-normative stuff around those sections.

Please feel free to merge if you think this improves the readability of the spec. With my fresh eyes this looks like an improvement.

Here's the HTML formatted version with the suggested changes baked to make it easier to review: https://rawgit.com/anssiko/manifest/reorg/index.html The best way to start the review is probably to compare the ToCs. TL;DR: no content was dropped, some content added, non-normative changes to wording etc.
