### PR TITLE
Simplify CPS model for manifest (closes #259)

### DIFF
--- a/images/manifest-src-directive.svg
+++ b/images/manifest-src-directive.svg
@@ -1,71 +1,63 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="704px" height="342px" viewBox="0 0 704 342" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
-    <title>Untitled 3</title>
+<svg width="701px" height="337px" viewBox="0 0 701 337" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <title>Untitled 2</title>
     <description>Created with Sketch (http://www.bohemiancoding.com/sketch)</description>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
-        <rect id="Rectangle-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup" x="97" y="0" width="61" height="70"></rect>
-        <path d="M162.023212,67.0285072 C157.463513,60.9400623 150.191882,57 142,57 C141.090229,57 140.191809,57.0485959 139.307193,57.1433335 C136.557402,53.9915101 132.511272,52 128,52 C122.302031,52 117.346102,55.1770547 114.807032,59.8563479 L114.807032,59.8563479 C112.333921,58.0596519 109.290708,57 106,57 C97.7157283,57 91,63.7157283 91,72 C91,72.382818 91.0143407,72.7622865 91.0425141,73.1378976 C90.3746534,73.0469694 89.6928119,73 89,73 C80.7157283,73 74,79.7157283 74,88 C74,96.2842717 80.7157283,103 89,103 C91.0213401,103 92.9492975,102.600181 94.7091025,101.875313 L94.7091025,101.875313 C97.4585697,105.016343 101.497631,107 106,107 C108.732154,107 111.2937,106.269543 113.5,104.993267 C115.7063,106.269543 118.267846,107 121,107 C124.398952,107 127.53386,105.869489 130.04922,103.96397 L130.04922,103.96397 C133.599637,105.899876 137.671344,107 142,107 C145.672619,107 149.160272,106.208069 152.301511,104.785656 C154.907822,106.200897 157.865257,107 161,107 C171.493411,107 180,98.0456955 180,87 C180,76.315647 172.040867,67.5880902 162.023219,67.0285076 Z" id="Oval-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
-        <rect id="Rectangle-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup" x="97" y="229" width="61" height="97"></rect>
-        <rect id="Rectangle-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup" x="367" y="230" width="61" height="97"></rect>
-        <rect id="Rectangle-4" stroke="#979797" fill="#7ED321" sketch:type="MSShapeGroup" x="2" y="167" width="251" height="51" rx="8"></rect>
-        <rect id="Rectangle-4" stroke="#979797" fill="#4990E2" sketch:type="MSShapeGroup" x="276" y="167" width="244" height="51" rx="8"></rect>
-        <text id="Policy-A" sketch:type="MSTextLayer" font-family="Helvetica" font-size="12" font-weight="normal" fill="#000000">
-            <tspan x="15" y="199">Policy A</tspan>
-        </text>
-        <text id="HTML" sketch:type="MSTextLayer" font-family="Helvetica" font-size="12" font-weight="normal" fill="#000000">
-            <tspan x="111" y="277">HTML</tspan>
-        </text>
-        <text id="Manifest" sketch:type="MSTextLayer" font-family="Helvetica" font-size="12" font-weight="normal" fill="#000000">
-            <tspan x="375" y="275">Manifest</tspan>
-        </text>
-        <text id="example.com" sketch:type="MSTextLayer" font-family="Helvetica" font-size="12" font-weight="normal" fill="#000000">
-            <tspan x="91" y="88">example.com</tspan>
-        </text>
-        <rect id="Rectangle-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup" x="367" y="0" width="61" height="70"></rect>
-        <path d="M433.023212,67.0285072 C428.463513,60.9400623 421.191882,57 413,57 C412.090229,57 411.191809,57.0485959 410.307193,57.1433335 C407.557402,53.9915101 403.511272,52 399,52 C393.302031,52 388.346102,55.1770547 385.807032,59.8563479 L385.807032,59.8563479 C383.333921,58.0596519 380.290708,57 377,57 C368.715728,57 362,63.7157283 362,72 C362,72.382818 362.014341,72.7622865 362.042514,73.1378976 C361.374653,73.0469694 360.692812,73 360,73 C351.715728,73 345,79.7157283 345,88 C345,96.2842717 351.715728,103 360,103 C362.02134,103 363.949297,102.600181 365.709103,101.875313 L365.709103,101.875313 C368.45857,105.016343 372.497631,107 377,107 C379.732154,107 382.2937,106.269543 384.5,104.993267 C386.7063,106.269543 389.267846,107 392,107 C395.398952,107 398.53386,105.869489 401.04922,103.96397 L401.04922,103.96397 C404.599637,105.899876 408.671344,107 413,107 C416.672619,107 420.160272,106.208069 423.301511,104.785656 C425.907822,106.200897 428.865257,107 432,107 C442.493411,107 451,98.0456955 451,87 C451,76.315647 443.040867,67.5880902 433.023219,67.0285076 Z" id="Oval-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
-        <text id="bar.com" sketch:type="MSTextLayer" font-family="Helvetica" font-size="12" font-weight="normal" fill="#000000">
-            <tspan x="377" y="85">bar.com</tspan>
-        </text>
-        <path d="M127.5,95.5 L127.5,166.5" id="Line" stroke="#979797" stroke-linecap="round" stroke-linejoin="round" sketch:type="MSShapeGroup"></path>
-        <path id="Line-decoration-1" d="M127.5,166.5 C128.55,162.72 129.45,159.48 130.5,155.7 C128.4,155.7 126.6,155.7 124.5,155.7 C125.55,159.48 126.45,162.72 127.5,166.5 C127.5,166.5 127.5,166.5 127.5,166.5 Z" stroke="#979797" stroke-linecap="round" stroke-linejoin="round"></path>
-        <path d="M398.5,95.5 L398.5,166.5" id="Line" stroke="#979797" stroke-linecap="round" stroke-linejoin="round" sketch:type="MSShapeGroup"></path>
-        <path id="Line-decoration-1" d="M398.5,166.5 C399.55,162.72 400.45,159.48 401.5,155.7 C399.4,155.7 397.6,155.7 395.5,155.7 C396.55,159.48 397.45,162.72 398.5,166.5 C398.5,166.5 398.5,166.5 398.5,166.5 Z" stroke="#979797" stroke-linecap="round" stroke-linejoin="round"></path>
-        <rect id="Rectangle-1-copy" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup" x="587" y="0" width="61" height="70"></rect>
-        <path d="M652.023212,67.0285072 C647.463513,60.9400623 640.191882,57 632,57 C631.090229,57 630.191809,57.0485959 629.307193,57.1433335 C626.557402,53.9915101 622.511272,52 618,52 C612.302031,52 607.346102,55.1770547 604.807032,59.8563479 L604.807032,59.8563479 C602.333921,58.0596519 599.290708,57 596,57 C587.715728,57 581,63.7157283 581,72 C581,72.382818 581.014341,72.7622865 581.042514,73.1378976 C580.374653,73.0469694 579.692812,73 579,73 C570.715728,73 564,79.7157283 564,88 C564,96.2842717 570.715728,103 579,103 C581.02134,103 582.949297,102.600181 584.709103,101.875313 L584.709103,101.875313 C587.45857,105.016343 591.497631,107 596,107 C598.732154,107 601.2937,106.269543 603.5,104.993267 C605.7063,106.269543 608.267846,107 611,107 C614.398952,107 617.53386,105.869489 620.04922,103.96397 L620.04922,103.96397 C623.599637,105.899876 627.671344,107 632,107 C635.672619,107 639.160272,106.208069 642.301511,104.785656 C644.907822,106.200897 647.865257,107 651,107 C661.493411,107 670,98.0456955 670,87 C670,76.315647 662.040867,67.5880902 652.023219,67.0285076 Z" id="Oval-1-copy" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
-        <text id="icons.com" sketch:type="MSTextLayer" font-family="Helvetica" font-size="12" font-weight="normal" fill="#000000">
-            <tspan x="590" y="88">icons.com</tspan>
-        </text>
-        <path d="M131.497041,257.5 L364.508591,257.5" id="Line" stroke="#979797" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
-        <path id="Line-decoration-1" d="M364.49704,257.5 C360.71704,256.45 357.47704,255.55 353.69704,254.5 C353.69704,256.6 353.69704,258.4 353.69704,260.5 C357.47704,259.45 360.71704,258.55 364.49704,257.5 C364.49704,257.5 364.49704,257.5 364.49704,257.5 Z" stroke="#979797" stroke-linecap="square"></path>
-        <path d="M416.497041,258.5 L583.5,258.5" id="Line" stroke="#979797" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
-        <path id="Line-decoration-1" d="M583.49704,258.5 C579.71704,257.45 576.47704,256.55 572.69704,255.5 C572.69704,257.6 572.69704,259.4 572.69704,261.5 C576.47704,260.45 579.71704,259.55 583.49704,258.5 C583.49704,258.5 583.49704,258.5 583.49704,258.5 Z" stroke="#979797" stroke-linecap="square"></path>
-        <path d="M127.5,208.5 L127.5,257.75444" id="Line" stroke="#979797" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
-        <path id="Line-decoration-1" d="M127.5,257.5 C128.55,253.72 129.45,250.48 130.5,246.7 C128.4,246.7 126.6,246.7 124.5,246.7 C125.55,250.48 126.45,253.72 127.5,257.5 C127.5,257.5 127.5,257.5 127.5,257.5 Z" stroke="#979797" stroke-linecap="square"></path>
-        <path d="M398.5,206.5 L398.5,254.759712" id="Line" stroke="#979797" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
-        <path id="Line-decoration-1" d="M398.5,254.5 C399.55,250.72 400.45,247.48 401.5,243.7 C399.4,243.7 397.6,243.7 395.5,243.7 C396.55,247.48 397.45,250.72 398.5,254.5 C398.5,254.5 398.5,254.5 398.5,254.5 Z" stroke="#979797" stroke-linecap="square"></path>
-        <text id="manifest-src-bar.com" sketch:type="MSTextLayer" font-family="Courier New" font-size="14" font-weight="normal" fill="#000000">
-            <tspan x="77" y="197">manifest-src bar.com</tspan>
-        </text>
-        <g id="Policy-B-+-img-src-icons.com" sketch:type="MSLayerGroup" transform="translate(299.000000, 183.000000)" fill="#000000" font-weight="normal">
-            <text id="Policy-B" sketch:type="MSTextLayer" font-family="Helvetica" font-size="12">
-                <tspan x="0" y="14">Policy B</tspan>
+        <g id="Group" sketch:type="MSLayerGroup" transform="translate(1.000000, 1.000000)">
+            <rect id="Rectangle-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup" x="95" y="0" width="61" height="70"></rect>
+            <path d="M160.023212,67.0285072 C155.463513,60.9400623 148.191882,57 140,57 C139.090229,57 138.191809,57.0485959 137.307193,57.1433335 C134.557402,53.9915101 130.511272,52 126,52 C120.302031,52 115.346102,55.1770547 112.807032,59.8563479 L112.807032,59.8563479 C110.333921,58.0596519 107.290708,57 104,57 C95.7157283,57 89,63.7157283 89,72 C89,72.382818 89.0143407,72.7622865 89.0425141,73.1378976 C88.3746534,73.0469694 87.6928119,73 87,73 C78.7157283,73 72,79.7157283 72,88 C72,96.2842717 78.7157283,103 87,103 C89.0213401,103 90.9492975,102.600181 92.7091025,101.875313 L92.7091025,101.875313 C95.4585697,105.016343 99.497631,107 104,107 C106.732154,107 109.2937,106.269543 111.5,104.993267 C113.7063,106.269543 116.267846,107 119,107 C122.398952,107 125.53386,105.869489 128.04922,103.96397 L128.04922,103.96397 C131.599637,105.899876 135.671344,107 140,107 C143.672619,107 147.160272,106.208069 150.301511,104.785656 C152.907822,106.200897 155.865257,107 159,107 C169.493411,107 178,98.0456955 178,87 C178,76.315647 170.040867,67.5880902 160.023219,67.0285076 L160.023212,67.0285072 Z" id="Oval-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
+            <rect id="Rectangle-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup" x="95" y="229" width="61" height="97"></rect>
+            <rect id="Rectangle-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup" x="365" y="230" width="61" height="97"></rect>
+            <rect id="Rectangle-4" stroke="#979797" fill="#7ED321" sketch:type="MSShapeGroup" x="0" y="167" width="251" height="51" rx="8"></rect>
+            <text id="Policy" fill="#000000" sketch:type="MSTextLayer" font-family="Helvetica" font-size="12" font-weight="normal">
+                <tspan x="13" y="199">Policy</tspan>
             </text>
-            <text id="img-src-icons.com" sketch:type="MSTextLayer" font-family="Courier New" font-size="14">
-                <tspan x="54" y="12">img-src icons.com</tspan>
+            <text id="HTML" fill="#000000" sketch:type="MSTextLayer" font-family="Helvetica" font-size="12" font-weight="normal">
+                <tspan x="109" y="277">HTML</tspan>
+            </text>
+            <text id="Manifest" fill="#000000" sketch:type="MSTextLayer" font-family="Helvetica" font-size="12" font-weight="normal">
+                <tspan x="373" y="275">Manifest</tspan>
+            </text>
+            <text id="example.com" fill="#000000" sketch:type="MSTextLayer" font-family="Helvetica" font-size="12" font-weight="normal">
+                <tspan x="89" y="88">example.com</tspan>
+            </text>
+            <rect id="Rectangle-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup" x="365" y="0" width="61" height="70"></rect>
+            <path d="M431.023212,67.0285072 C426.463513,60.9400623 419.191882,57 411,57 C410.090229,57 409.191809,57.0485959 408.307193,57.1433335 C405.557402,53.9915101 401.511272,52 397,52 C391.302031,52 386.346102,55.1770547 383.807032,59.8563479 L383.807032,59.8563479 C381.333921,58.0596519 378.290708,57 375,57 C366.715728,57 360,63.7157283 360,72 C360,72.382818 360.014341,72.7622865 360.042514,73.1378976 C359.374653,73.0469694 358.692812,73 358,73 C349.715728,73 343,79.7157283 343,88 C343,96.2842717 349.715728,103 358,103 C360.02134,103 361.949297,102.600181 363.709103,101.875313 L363.709103,101.875313 C366.45857,105.016343 370.497631,107 375,107 C377.732154,107 380.2937,106.269543 382.5,104.993267 C384.7063,106.269543 387.267846,107 390,107 C393.398952,107 396.53386,105.869489 399.04922,103.96397 L399.04922,103.96397 C402.599637,105.899876 406.671344,107 411,107 C414.672619,107 418.160272,106.208069 421.301511,104.785656 C423.907822,106.200897 426.865257,107 430,107 C440.493411,107 449,98.0456955 449,87 C449,76.315647 441.040867,67.5880902 431.023219,67.0285076 L431.023212,67.0285072 Z" id="Oval-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
+            <text id="bar.com" fill="#000000" sketch:type="MSTextLayer" font-family="Helvetica" font-size="12" font-weight="normal">
+                <tspan x="375" y="85">bar.com</tspan>
+            </text>
+            <path d="M125.5,95.5 L125.5,172.5" id="Line" stroke="#979797" sketch:type="MSShapeGroup"></path>
+            <path d="M125.5,180.5 L128.5,169.7 L122.5,169.7 L125.5,180.5 L125.5,180.5 L125.5,180.5 Z" id="Line-decoration-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
+            <path d="M396.5,95.5 L396.5,251.5" id="Line" stroke="#979797" sketch:type="MSShapeGroup"></path>
+            <rect id="Rectangle-1-copy" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup" x="585" y="0" width="61" height="70"></rect>
+            <path d="M650.023212,67.0285072 C645.463513,60.9400623 638.191882,57 630,57 C629.090229,57 628.191809,57.0485959 627.307193,57.1433335 C624.557402,53.9915101 620.511272,52 616,52 C610.302031,52 605.346102,55.1770547 602.807032,59.8563479 L602.807032,59.8563479 C600.333921,58.0596519 597.290708,57 594,57 C585.715728,57 579,63.7157283 579,72 C579,72.382818 579.014341,72.7622865 579.042514,73.1378976 C578.374653,73.0469694 577.692812,73 577,73 C568.715728,73 562,79.7157283 562,88 C562,96.2842717 568.715728,103 577,103 C579.02134,103 580.949297,102.600181 582.709103,101.875313 L582.709103,101.875313 C585.45857,105.016343 589.497631,107 594,107 C596.732154,107 599.2937,106.269543 601.5,104.993267 C603.7063,106.269543 606.267846,107 609,107 C612.398952,107 615.53386,105.869489 618.04922,103.96397 L618.04922,103.96397 C621.599637,105.899876 625.671344,107 630,107 C633.672619,107 637.160272,106.208069 640.301511,104.785656 C642.907822,106.200897 645.865257,107 649,107 C659.493411,107 668,98.0456955 668,87 C668,76.315647 660.040867,67.5880902 650.023219,67.0285076 L650.023212,67.0285072 Z" id="Oval-1-copy" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
+            <text id="icons.com" fill="#000000" sketch:type="MSTextLayer" font-family="Helvetica" font-size="12" font-weight="normal">
+                <tspan x="588" y="88">icons.com</tspan>
+            </text>
+            <path d="M129.497041,257.5 L362.508591,257.5" id="Line" stroke="#979797" sketch:type="MSShapeGroup"></path>
+            <path d="M362.49704,257.5 L351.69704,254.5 L351.69704,260.5 C355.47704,259.45 358.71704,258.55 362.49704,257.5 L362.49704,257.5 L362.49704,257.5 Z" id="Line-decoration-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
+            <path d="M414.497041,258.5 L581.5,258.5" id="Line" stroke="#979797" sketch:type="MSShapeGroup"></path>
+            <path d="M581.49704,258.5 L570.69704,255.5 L570.69704,261.5 C574.47704,260.45 577.71704,259.55 581.49704,258.5 L581.49704,258.5 L581.49704,258.5 Z" id="Line-decoration-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
+            <path d="M125.5,208.5 L125.5,257.75444" id="Line" stroke="#979797" sketch:type="MSShapeGroup"></path>
+            <path d="M125.5,257.5 L128.5,246.7 L122.5,246.7 L125.5,257.5 L125.5,257.5 L125.5,257.5 Z" id="Line-decoration-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
+            <path d="M396.5,254.5 L399.5,243.7 L393.5,243.7 L396.5,254.5 L396.5,254.5 L396.5,254.5 Z" id="Line-decoration-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
+            <text id="manifest-src-bar.com" fill="#000000" sketch:type="MSTextLayer" font-family="Courier New" font-size="12.3586207" font-weight="normal">
+                <tspan x="75" y="189">manifest-src bar.com</tspan>
+                <tspan x="75" y="203">image-src icons.com</tspan>
+            </text>
+            <path d="M589.499999,241.25 L573.335907,249.747968 L576.422973,231.748984 L563.345946,219.002033 L581.417955,216.376014 L589.5,200 L597.58205,216.376018 L615.654059,219.002046 L602.577026,231.748988 L605.664093,249.747969 L589.499999,241.25 Z" id="Star-1" stroke="#979797" fill="#F6A623" sketch:type="MSShapeGroup"></path>
+            <path d="M623.499999,300.25 L607.335907,308.747968 L610.422973,290.748984 L597.345946,278.002033 L615.417955,275.376014 L623.5,259 L631.58205,275.376018 L649.654059,278.002046 L636.577026,290.748988 L639.664093,308.747969 L623.499999,300.25 Z" id="Star-1-copy" stroke="#979797" fill="#F6A623" sketch:type="MSShapeGroup"></path>
+            <path d="M673.499999,268.25 L657.335907,276.747968 L660.422973,258.748984 L647.345946,246.002033 L665.417955,243.376014 L673.5,227 L681.58205,243.376018 L699.654059,246.002046 L686.577026,258.748988 L689.664093,276.747969 L673.499999,268.25 Z" id="Star-1-copy-2" stroke="#979797" fill="#F6A623" sketch:type="MSShapeGroup"></path>
+            <path d="M614.5,106.5 L605.5,211.5" id="Line" stroke="#979797" sketch:type="MSShapeGroup"></path>
+            <path d="M605.53288,211.116397 C606.901861,207.439878 608.075272,204.288576 609.444253,200.612057 C607.351925,200.432714 605.558501,200.278992 603.466173,200.09965 C604.18952,203.955511 604.809533,207.260535 605.53288,211.116397 L605.53288,211.116397 L605.53288,211.116397 Z" id="Line-decoration-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
+            <path d="M634.5,106.5 L662.5,240.5" id="Line" stroke="#979797" sketch:type="MSShapeGroup"></path>
+            <path d="M662.317119,239.624784 C662.571768,235.709933 662.790039,232.354347 663.044689,228.439497 C660.989085,228.869026 659.22714,229.237193 657.171536,229.666723 C658.97249,233.152044 660.516165,236.139462 662.317119,239.624784 L662.317119,239.624784 L662.317119,239.624784 Z" id="Line-decoration-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
+            <path d="M619.5,104.5 L631.5,257.5" id="Line" stroke="#979797" sketch:type="MSShapeGroup"></path>
+            <path d="M631.463261,257.031575 L633.60961,246.030066 L627.62798,246.499214 C628.970328,250.18554 630.120913,253.345248 631.463261,257.031575 L631.463261,257.031575 L631.463261,257.031575 Z" id="Line-decoration-1" stroke="#979797" fill="#D8D8D8" sketch:type="MSShapeGroup"></path>
+            <text id="icons" fill="#000000" sketch:type="MSTextLayer" font-family="Helvetica" font-size="14" font-weight="normal">
+                <tspan x="610" y="335">icons</tspan>
             </text>
         </g>
-        <polygon id="Star-1" stroke="#979797" fill="#F6A623" sketch:type="MSShapeGroup" points="591.499999 241.25 575.335907 249.747968 578.422973 231.748984 565.345946 219.002033 583.417955 216.376014 591.5 200 599.58205 216.376018 617.654059 219.002046 604.577026 231.748988 607.664093 249.747969 "></polygon>
-        <polygon id="Star-1-copy" stroke="#979797" fill="#F6A623" sketch:type="MSShapeGroup" points="625.499999 300.25 609.335907 308.747968 612.422973 290.748984 599.345946 278.002033 617.417955 275.376014 625.5 259 633.58205 275.376018 651.654059 278.002046 638.577026 290.748988 641.664093 308.747969 "></polygon>
-        <polygon id="Star-1-copy-2" stroke="#979797" fill="#F6A623" sketch:type="MSShapeGroup" points="675.499999 268.25 659.335907 276.747968 662.422973 258.748984 649.345946 246.002033 667.417955 243.376014 675.5 227 683.58205 243.376018 701.654059 246.002046 688.577026 258.748988 691.664093 276.747969 "></polygon>
-        <path d="M616.5,106.5 L607.5,211.5" id="Line" stroke="#979797" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
-        <path id="Line-decoration-1" d="M607.53288,211.116397 C608.901861,207.439878 610.075272,204.288576 611.444253,200.612057 C609.351925,200.432714 607.558501,200.278992 605.466173,200.09965 C606.18952,203.955511 606.809533,207.260535 607.53288,211.116397 C607.53288,211.116397 607.53288,211.116397 607.53288,211.116397 Z" stroke="#979797" stroke-linecap="square"></path>
-        <path d="M636.5,106.5 L664.5,240.5" id="Line" stroke="#979797" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
-        <path id="Line-decoration-1" d="M664.317119,239.624784 C664.571768,235.709933 664.790039,232.354347 665.044689,228.439497 C662.989085,228.869026 661.22714,229.237193 659.171536,229.666723 C660.97249,233.152044 662.516165,236.139462 664.317119,239.624784 C664.317119,239.624784 664.317119,239.624784 664.317119,239.624784 Z" stroke="#979797" stroke-linecap="square"></path>
-        <path d="M621.5,104.5 L633.5,257.5" id="Line" stroke="#979797" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
-        <path id="Line-decoration-1" d="M633.463261,257.031575 C634.214483,253.181047 634.858388,249.880594 635.60961,246.030066 C633.51604,246.194268 631.721551,246.335012 629.62798,246.499214 C630.970328,250.18554 632.120913,253.345248 633.463261,257.031575 C633.463261,257.031575 633.463261,257.031575 633.463261,257.031575 Z" stroke="#979797" stroke-linecap="square"></path>
-        <text id="icons" sketch:type="MSTextLayer" font-family="Helvetica" font-size="14" font-weight="normal" fill="#000000">
-            <tspan x="612" y="335">icons</tspan>
-        </text>
     </g>
 </svg>

--- a/index.html
+++ b/index.html
@@ -1156,52 +1156,28 @@ Content-Type: application/manifest+json
           Content security policy
         </h3>
         <p class="issue">
-          The `<code>manifest-src</code>` hasn't yet been added to the CSP
+          The `<code>manifest-src</code>` hasn't yet been added to the [[!CSP]]
           spec. However, a <a href=
           "https://github.com/w3c/webappsec/issues/29">feature request has been
-          filed</a> and accepted by the Editor.
+          filed</a> and a <a href=
+          "https://github.com/w3c/webappsec/pull/66">pull request
+          submitted</a>.
         </p>
         <p>
-          Just like [[!HTML]] documents, a manifest can have an associated
-          [[!CSP]] policy. The manifest's policy controls, for example, where
-          resources like <a title="icon object">icons</a> can be loaded from
-          (via the <code><a href=
-          "https://w3c.github.io/webappsec/specs/content-security-policy/#directive-img-src">
-          img-src</a></code> directive).
-        </p>
-        <p>
-          A user agent MUST treat the a manifest's policy as independent of any
-          policy applied to [[!HTML]] document. A manifest's [[!CSP]] policy
-          can only be delivered over HTTP.
-        </p>
-        <div class="example">
-          <figure>
-            <img src="images/indipendent_policies.svg" width="224" height="332"
-            alt="">
-            <figcaption>
-              The [[!CSP]] policy applied to a [[!HTML]] document is
-              independent from, and does not interact with, the policy applied
-              to the manifest. Where are manifest can be loaded from is
-              controlled by the HTML's document's CSP policy.
-            </figcaption>
-          </figure>
-        </div>
-        <p>
-          For [[!HTML]] document, [[!CSP]]'s <code>manifest-src</code>
-          directive controls the sources from which a [[!HTML]] document can
-          load a manifest from.
+          The security policy that governs whether a <a>user agent</a> can
+          fetch a <code>Document</code>'s <a>manifest</a> is governed by the
+          <code>manifest-src</code> [[!CSP]] associated of the manifest's owner
+          <code>Document</code>.
         </p>
         <div class="example">
           <figure class="exaple">
             <img src="images/manifest-src-directive.svg" width="704" height=
             "342" alt="">
             <figcaption>
-              The `<code>manifest-src</code>` directive controls where an HTML
-              document can load a manifest from. In this case, it's from
-              "bar.com". In turn, bar.com applies its own policy to the
-              manifest, which itself restricts where, for instance, <a title=
-              "icon object">icons</a> can be loaded from. In this case, that is
-              from "icons.com".
+              For a [[!HTML]] document, [[!CSP]]'s <code>manifest-src</code>
+              directive controls the sources from which a [[!HTML]] document
+              can load a manifest from. The same policy, via the image-src
+              directive, controls where the icon's images can be fetched from.
             </figcaption>
           </figure>
         </div>
@@ -1243,8 +1219,9 @@ Content-Type: application/manifest+json
           Content security policy of icon object
         </h3>
         <p>
-          Fetching icons is governed by the <code>img-src</code> CSP directive
-          as applied to the manifest.
+          The security policy that governs wether a <a>user agent</a> can fetch
+          an icon image is governed by the <code>image-src</code> directive
+          [[!CSP]] associated of the manifest's owner <code>Document</code>.
         </p>
         <div class="example">
           <p>


### PR DESCRIPTION
- no longer allow the manifest to have a different policy. Depend's on owner document's CSP.
- SVG figure reflects the change above. 

@kenchris, this is for you. 
