### PR TITLE
Fix links to "SchemaStore" GitHub repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -2803,9 +2803,9 @@ Content-Security-Policy: img-src icons.example.com;
         2.0</a>. It is kindly maintained by <a href=
         "https://github.com/madskristensen">Mads Kristensen</a>. If you find
         any issues with the JSON schema, please <a href=
-        "https://github.com/madskristensen/SchemaStore/issues/">file a bug</a>
+        "https://github.com/SchemaStore/schemastore/issues/">file a bug</a>
         at the <a href=
-        "https://github.com/madskristensen/SchemaStore/">SchemaStore
+        "https://github.com/SchemaStore/schemastore">SchemaStore
         repository</a> on GitHub.
       </p>
     </section>


### PR DESCRIPTION
![](https://cloud.githubusercontent.com/assets/1223565/7035409/e8ce07b0-dd90-11e4-89f4-1d3ec2e0d5c7.png)

--

It seems that the SchemaStore repository was moved from https://github.com/madskristensen/SchemaStore/ to https://github.com/SchemaStore/schemastore.