### PR TITLE
Rename the spec to "Web App Manifest" to align with the established name

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>
-      Manifest for a web application
+      Web App Manifest
     </title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class=
     "remove">
@@ -318,7 +318,7 @@
         <li>Otherwise, return <code>false</code>.
         </li>
       </ol>
-      <div class="issue" title="🐒 Monkey patch">
+      <div class="issue" title="&#128018; Monkey patch">
         <p>
           Enforcing the navigation scope depends on [[!HTML]]'s navigate
           algorithm. As such, the following algorithm monkey patches [[!HTML]].


### PR DESCRIPTION
Rename the spec to "Web App Manifest" to align with the [established name][1].

(I don't always bikeshed about naming, but when I do, I rename the spec.)

![](http://i.imgur.com/cOJlheK.jpg)

[1]: https://www.google.com/search?q=%22web%20app%20manifest%22