### PR TITLE
SVG icon sizes="any" (or without property "sizes")

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,7 +193,8 @@
 &lt;meta name="application-name" content="Store Finder"&gt;
 &lt;link rel="icon" sizes="16x16 32x32 48x48" href="lo_def.ico"&gt;
 &lt;link rel="icon" sizes="512x512" href="hi_def.png"&gt;
-&lt;link rel="icon" sizes="any" href="icon.png"&gt;
+&lt;link rel="icon" sizes="any" href="icon.svg"&gt;
+&lt;link rel="icon" href="icon-repace.svg"&gt;
 </pre>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -193,6 +193,7 @@
 &lt;meta name="application-name" content="Store Finder"&gt;
 &lt;link rel="icon" sizes="16x16 32x32 48x48" href="lo_def.ico"&gt;
 &lt;link rel="icon" sizes="512x512" href="hi_def.png"&gt;
+&lt;link rel="icon" sizes="any" href="icon.png"&gt;
 </pre>
       </section>
     </section>
@@ -1383,6 +1384,9 @@ Content-Type: application/manifest+json
             (hd_hi.ico), which includes a gamut of icons individually tailored
             for small display sizes.
             </li>
+            <li>SVG icon <code>sizes</code> <strong>any</strong> for any icon size, 
+            apply it always until specified icons with different sizes like 72x72, 
+            48x48, etc.</li>
           </ul>
           <pre class="">
 {
@@ -1401,6 +1405,9 @@ Content-Type: application/manifest+json
         "src": "icon/hd_hi.svg",
         "sizes": "72x72",
         "density": 2
+      },{
+        "src": "icon/icon.svg",
+        "sizes": "any"
       }]
  }
 </pre>

--- a/index.html
+++ b/index.html
@@ -1386,7 +1386,7 @@ Content-Type: application/manifest+json
             </li>
             <li>SVG icon <code>sizes</code> <strong>any</strong> for any icon size, 
             apply it always until specified icons with different sizes like 72x72, 
-            48x48, etc.</li>
+            48x48, etc. The same must behavior also without specifying <code>sizes</code> at all.</li>
           </ul>
           <pre class="">
 {


### PR DESCRIPTION
SVG icon sizes="any" for any icon size, apply it always until specified icons with different sizes like 72x72, 48x48, etc.
The same logic also for "link" element.

Maybe we can even drop "sizes" property if the image type is SVG image/svg+xml. It is understandable that SVG image is scalable.
Speaking about "link" element, Apple earlier proposed with sizes="any" and later dropped that property, see spec https://developer.apple.com/library/safari/releasenotes/General/WhatsNewInSafari/Articles/Safari_9.html#//apple_ref/doc/uid/TP40014305-CH9-SW20. Has been shipped it Firefox 41 https://bugzilla.mozilla.org/show_bug.cgi?id=366324, Chrome still working on it https://code.google.com/p/chromium/issues/detail?id=294179. Related issue in https://github.com/whatwg/html/issues/110