### PR TITLE
Migrate to the Web Platform WG

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,10 +39,10 @@
             companyURL: "http://intel.com",
             w3cid: 41974
         }],
-        wg: 'Web Applications (WebApps) Working Group',
+        wg: 'Web Platform Working Group',
         wgURI: 'http://www.w3.org/2008/webapps/',
         wgPublicList: 'public-webapps',
-        wgPatentURI: 'http://www.w3.org/2004/01/pp-impl/42538/status',
+        wgPatentURI: 'http://www.w3.org/2004/01/pp-impl/83482/status',
         noLegacyStyle: true,
         otherLinks: [{
             key: 'Repository',

--- a/index.html
+++ b/index.html
@@ -2785,8 +2785,8 @@ Content-Security-Policy: img-src icons.example.com
             Person &amp; email address to contact for further information:
           </dt>
           <dd>
-            The <a href="http://www.w3.org/2008/webapps/" rel="nofollow">Web
-            Applications (WebApps) Working Group</a> can be contacted at
+            The <a href="https://www.w3.org/WebPlatform/WG/" rel="nofollow">Web
+            Platform Working Group</a> can be contacted at
             <a href="https://lists.w3.org/Archives/Public/public-webapps/" rel=
             "nofollow">public-webapps@w3.org</a>.
           </dd>
@@ -2806,7 +2806,7 @@ Content-Security-Policy: img-src icons.example.com
             Author:
           </dt>
           <dd>
-            W3C's Web Applications (WebApps) Working Group.
+            W3C's Web Platform Working Group.
           </dd>
           <dt>
             Change controller:


### PR DESCRIPTION
Given the [Web Platform WG][1] was started 10 Oct [terminating][2] the WebApps WG, I guess we want to update the boilerplate to match. This spec is listed in the [WPWG's deliverables][3].

[1]: https://www.w3.org/WebPlatform/WG/
[2]: https://lists.w3.org/Archives/Public/public-webapps/2015OctDec/0058.html
[3]: http://www.w3.org/2015/10/webplatform-charter.html#deliverables