### PR TITLE
Update README with the new spec name and WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-This repository is the home of the :star: **[Web Manifest](https://w3c.github.io/manifest/)** :star: specification being worked on by
-the [Web Applications Working Group](http://www.w3.org/2008/webapps/).
+This repository is the home of the :star: **[Web App Manifest](https://w3c.github.io/manifest/)** :star: specification being worked on by
+the [Web Platform Working Group](https://www.w3.org/WebPlatform/WG/).
 
 ## Useful links
-* [The Manifest specification](https://w3c.github.io/manifest/)
+* [The Web App Manifest specification](https://w3c.github.io/manifest/)
 * [Use cases and requirements](https://w3c-webmob.github.io/installable-webapps/)
-* [The WebApps WG homepage](http://www.w3.org/2008/webapps/)
+* [The Web Platform WG homepage](https://www.w3.org/WebPlatform/WG/)
 * [The WebApps WG mailing-list](https://lists.w3.org/Archives/Public/public-webapps/)


### PR DESCRIPTION
In related news, the automated publishing to TR should work again now after the WG changed: http://www.w3.org/TR/appmanifest/

This aligns the rest of the naming.

(And just when we did this rename, I noticed some people started use the name "Web Manifest". Oh well... agreeing on the color of the bikeshed is hard. Perhaps being consistent helps though :-) Personally I think the Web App Manifest name goes nicely along with the new Progressive Web App buzzword people are excited about (for a reason).)