### PR TITLE
Enable RDFa

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <script class='remove'>
 //make tidy happy
     var respecConfig = {
-        doRDFa: false,
+        doRDFa: true,
         previousPublishDate: "2013-12-17",
         specStatus: 'WD',
         shortName: 'appmanifest',


### PR DESCRIPTION
The ReSpec configuration for this specification disables RDFa generation.  RDFa generation is stable and mature in ReSpec and provides for more ready processing of W3C specifications by knowledge engines.  Please enable RDFA generation in your specification.