### PR TITLE
Remove reference to RFC5988.

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,9 +99,7 @@
       <p>
         To associate documents of a web application with a manifest, this
         specification defines the <code>manifest</code> link type as a
-        declarative means for a document to be associated with a manifest
-        (either directly in a HTML document or over the wire using
-        [[RFC5988]]).
+        declarative means for a document to be associated with a manifest.
       </p>
     </section>
     <section id="sotd">


### PR DESCRIPTION
As far as I know this is not implemented. Maybe someone has context about why it was added in the first place?

Closes #424.