### PR TITLE
6.2: Fix member name to splash_screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -970,7 +970,7 @@ Content-Type: application/manifest+json
           <li>Let <var>splash screens</var> of <var>parsed manifest</var> be
           the result of running the <a>steps for processing an array of
           images</a> with <var>manifest</var>, <var>manifest URL</var>, and
-          "splash_screen" as arguments.
+          "splash_screens" as arguments.
           </li>
           <li>Let <var>scope</var> of <var>parsed manifest</var> be the result
           of running the <a>steps for processing the <code>scope</code>


### PR DESCRIPTION
The member name is listed as "splash_screen" (singular) but it is "splash_screens" (plural) in other places throughout the spec.