### PR TITLE
Review of the installation event feature (#453)

### DIFF
--- a/index.html
+++ b/index.html
@@ -446,7 +446,7 @@ window.addEventListener("install", handleInstall);
         <li>Otherwise, return <code>false</code>.
         </li>
       </ol>
-      <div class="issue" title="&#128018; Monkey patch">
+      <div class="issue" title="🐒 Monkey patch">
         <p>
           Enforcing the navigation scope depends on [[!HTML]]'s navigate
           algorithm. As such, the following algorithm monkey patches [[!HTML]].

--- a/index.html
+++ b/index.html
@@ -201,16 +201,16 @@
       </p>
       <p>
         For example, on user agents that support installation, a web
-        application could be presented and and launched in a way that, to the
+        application could be presented and launched in a way that, to the
         end-user, is indistinguishable from native applications: such as
         appearing as a labeled icon on the home screen, launcher, or start
         menu. When launched, the manifest is <a>applied</a> by the user agent
-        to the browsing context prior to the <a>start URL</a> being loaded.
-        This gives the user agent time to apply the relevant values of the
-        manifest, possibly changing the <a>display mode</a> and screen
-        orientation of the web application. Alternatively, and again as an
-        example, the user agent could <a>install</a> the web application into a
-        list of bookmarks within the user agent itself.
+        to the <a>top-level browsing context</a> prior to the <a>start URL</a>
+        being loaded. This gives the user agent time to apply the relevant
+        values of the manifest, possibly changing the <a>display mode</a> and
+        screen orientation of the web application. Alternatively, and again as
+        an example, the user agent could <a>install</a> the web application
+        into a list of bookmarks within the user agent itself.
       </p>
       <p>
         An end-user can <dfn data-lt="manual installation">manually</dfn>
@@ -269,7 +269,7 @@
         </h3>
         <p>
           The <dfn>steps to install the web application</dfn> are given by the
-          following algorithm.:
+          following algorithm:
         </p>
         <ol>
           <li>Let <var>window</var> be the <code>Window</code> object of the
@@ -282,8 +282,8 @@
           the manifest</a>.
           </li>
           <li>If <a>obtaining the manifest</a> results in an error, a user
-          agent can, at this point, fall back to using the top-level browsing
-          contexts' <code>Document</code>'s metadata to create an
+          agent can, at this point, fall back to using the <a>top-level
+          browsing context</a>' <code>Document</code>'s metadata to create an
           <a>installation process</a>.
           </li>
           <li>If the <a>installation succeeded</a>, <a>fire an event</a> named
@@ -297,8 +297,8 @@
         </h3>
         <p>
           In the case that the end-user <a>manually</a> triggered the
-          installation process, the user agent MUST run the <a>steps to install
-          the web application</a>.
+          <a>installation process</a>, the user agent MUST run the <a>steps to
+          install the web application</a>.
         </p>
       </section>
       <section>
@@ -319,7 +319,7 @@
           It is RECOMMENDED that user agents prevent other applications from
           determining which applications are installed on the system (e.g., via
           a timing attack on the user agent's cache). This could be done by,
-          for example, invalidating from the user agent's cache resources were
+          for example, invalidating from the user agent's cache the resources
           linked to from the manifest (for example, icons) after a web
           application is <a>installed</a> - or by using an entirely different
           cache from that used for regular web browsing.
@@ -373,19 +373,19 @@
       </h2>
       <section>
         <h3>
-          <code>AppInstallEventHandlersMixin</code> mix-in
+          <code>AppInstallEventHandlers</code> mixin
         </h3>
         <p>
-          The <code>AppInstallEventHandlersMixin</code> defines the event
-          handler attributes on which events relating to the installation of a
-          web application are fired.
+          The <a><code>AppInstallEventHandlers</code></a> mixin defines the
+          event handler attributes on which events relating to the
+          <a>installation</a> of a web application are fired.
         </p>
         <pre class="idl">
           [NoInterfaceObject, exposed=(Window)]
-          interface AppInstallEventHandlersMixin {
+          interface AppInstallEventHandlers {
             attribute EventHandler oninstall;
           };
-          Window implements AppInstallEventHandlersMixin;
+          Window implements AppInstallEventHandlers;
         </pre>
         <div class="example">
           <p>
@@ -394,14 +394,14 @@
           <pre class="highlight">
 function handleInstall(ev){
   const date = new Date(ev.timeStamp / 1000);
-  console.log(`Yay! Our app got installed at ${date.toTimeString()}`)
+  console.log(`Yay! Our app got installed at ${date.toTimeString()}`);
 }
 
 // Using the event handler IDL attribute
 window.oninstall = handleInstall;
 
 // Using .addEventListener()
-window.addEventListener("install", handleInstall)
+window.addEventListener("install", handleInstall);
             </pre>
         </div>
         <section>
@@ -446,7 +446,7 @@ window.addEventListener("install", handleInstall)
         <li>Otherwise, return <code>false</code>.
         </li>
       </ol>
-      <div class="issue" title="🐒 Monkey patch">
+      <div class="issue" title="&#128018; Monkey patch">
         <p>
           Enforcing the navigation scope depends on [[!HTML]]'s navigate
           algorithm. As such, the following algorithm monkey patches [[!HTML]].
@@ -521,8 +521,8 @@ window.addEventListener("install", handleInstall)
         <p>
           An <a>application context</a> can be instantiated through a <a>deep
           link</a> (a URL that is within scope of the installed web
-          application); in which case, the manifest is applied and the deep
-          link is loaded within the context of a web application.
+          application); in which case, the manifest is applied and the <a>deep
+          link</a> is loaded within the context of a web application.
         </p>
         <div class="note">
           <p>


### PR DESCRIPTION
- rename `AppInstallEventHandlersMixin` to `AppInstallEventHandlers`
  (seem more consistent with the way mixins are named in HTML)
- fix JSHint warnings in examples (consistent use of semicolons)
- link to terms that have `<dfn>`s
- fix typos, minor editorial rewording
- make the monkey 🐒 an HTML entity!
- tidy