### PR TITLE
feat: add AppBannerPromptOutcome enum

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,6 +231,41 @@
         instance, there are sufficient <a>installability signals</a> to warrant
         <a>installation</a> of the web application.
       </p>
+      <section data-dfn-for="AppBannerPromptOutcome">
+        <h4>
+          <code>AppBannerPromptOutcome</code> enum
+        </h4>
+        <pre class="idl">
+          enum AppBannerPromptOutcome {
+            "accepted",
+            "dismissed"
+          };
+        </pre>
+        <p>
+          The <dfn>AppBannerPromptOutcome</dfn> enum's values represent the
+          outcomes from <a data-lt="presents an install prompt">presenting the
+          end-user with an install prompt</a>.
+        </p>
+        <dl data-dfn-for="AppBannerPromptOutcome">
+          <dt>
+            <dfn>accepted</dfn>:
+          </dt>
+          <dd>
+            The end-user indicated that they would like the user agent to
+            <a>install</a> the web application.
+            <p class="note">
+              This does not necessarily mean that the <a>installation
+              process</a> will <a data-lt="installation succeeded">succeed</a>.
+            </p>
+          </dd>
+          <dt>
+            <dfn>dismissed</dfn>:
+          </dt>
+          <dd>
+            The end-user dismissed the install prompt.
+          </dd>
+        </dl>
+      </section>
       <section>
         <h3>
           Authority of the manifest's metadata


### PR DESCRIPTION
Part 3, adds AppBannerPromptOutcome enum, which represents the outcome from showing an install prompt. 