### PR TITLE
[Index | Example manifests] Adds simple example

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,8 +136,8 @@
   "name": "Donate App",
   "description": "This app helps you donate to worthy causes.",
   "icons": [{
-    "src": "icon/lowres.png",
-    "sizes": "64x64"
+    "src": "images/icon.png",
+    "sizes": "192x192"
   }]
 }
 </pre>        <p>

--- a/index.html
+++ b/index.html
@@ -126,10 +126,22 @@
       </p>
       <section class="informative">
         <h3>
-          Example manifest
+          Example manifests
         </h3>
         <p>
-          The following shows a typical <a>manifest</a>.
+          The following shows a very simple <a>manifest</a>.
+        </p>
+        <pre class="example json" title="typical manifest">
+{
+  "name": "Donate App",
+  "description": "This app helps you donate to worthy causes.",
+  "icons": [{
+    "src": "icon/lowres.png",
+    "sizes": "64x64"
+  }]
+}
+</pre>        <p>
+          The following shows a more typical <a>manifest</a>.
         </p>
         <pre class="example json" title="typical manifest">
 {

--- a/index.html
+++ b/index.html
@@ -132,15 +132,16 @@
           The following shows a very simple <a>manifest</a>.
         </p>
         <pre class="example json" title="very simple manifest">
-{
-  "name": "Donate App",
-  "description": "This app helps you donate to worthy causes.",
-  "icons": [{
-    "src": "images/icon.png",
-    "sizes": "192x192"
-  }]
-}
-</pre>        <p>
+        {
+          "name": "Donate App",
+          "description": "This app helps you donate to worthy causes.",
+          "icons": [{
+            "src": "images/icon.png",
+            "sizes": "192x192"
+          }]
+        }
+        </pre>
+        <p>
           The following shows a more typical <a>manifest</a>.
         </p>
         <pre class="example json" title="typical manifest">

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
         <p>
           The following shows a very simple <a>manifest</a>.
         </p>
-        <pre class="example json" title="typical manifest">
+        <pre class="example json" title="very simple manifest">
 {
   "name": "Donate App",
   "description": "This app helps you donate to worthy causes.",


### PR DESCRIPTION
Adds a simple manifest example with name, description, and icons (just one)

This is intended to address the simple example part of Issue #533

Signed-off-by: Rob Dolin <robdolin@microsoft.com>