### PR TITLE
[Index | Example] Add Service Worker object

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,11 @@
   "orientation": "landscape",
   "theme_color": "aliceblue",
   "background_color": "red",
+  "serviceworker": {
+    "src": "sw.js",
+    "scope": "/racer",
+    "use_cache": false
+  },
   "screenshots": [{
     "src": "screenshots/in-game-1x.jpg",
     "sizes": "640x480",

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
   "background_color": "red",
   "serviceworker": {
     "src": "sw.js",
-    "scope": "/racer",
+    "scope": "/racer/",
     "use_cache": false
   },
   "screenshots": [{


### PR DESCRIPTION
Adds the service worker object to the complex example

@KenChris (or others) - would you please comment if you think scope should be:
 a) "/racer" - matching example in serviceworker section
 b) "/racer/" - matching the `scope` object earlier in the example

Signed-off-by: Rob Dolin <robdolin@microsoft.com>