### PR TITLE
Use data-cite

### DIFF
--- a/index.html
+++ b/index.html
@@ -1131,8 +1131,8 @@ if (standalone.matches) {
           algorithm.
           </li>
           <li>Let <var>text</var> be the result of <a>UTF-8 decoding</a> <var>
-            response</var>'s <a href=
-            "https://fetch.spec.whatwg.org/#concept-request-body">body</a>.
+            response</var>'s <a data-cite=
+            "fetch#concept-request-body">body</a>.
           </li>
           <li>Let <var>manifest</var> be the result of running the <a>steps for
           processing a manifest</a> with <var>text</var>, <var>manifest
@@ -3740,9 +3740,8 @@ Content-Security-Policy: img-src icons.example.com
       </p>
       <ul>
         <li>
-          <a href=
-          "https://encoding.spec.whatwg.org/#utf-8-decode"><dfn data-lt="utf-8 decoding">
-          UTF-8 decode</dfn></a>
+          <dfn data-cite="encoding#utf-8-decode" data-lt="utf-8 decoding">UTF-8
+          decode</dfn>
         </li>
       </ul>
     </section>


### PR DESCRIPTION
Fixes #570.

@marcoscaceres, I do use data-cite for other specs extensively. I followed the convention of this spec of not using it initially :-)

That said, we should move all the references to use data-cite, so I opened #573. 