### PR TITLE
Scope matching algorithm: fix and explain

### DIFF
--- a/index.html
+++ b/index.html
@@ -790,6 +790,15 @@ window.addEventListener("appinstalled", handleInstalled);
         <li>Otherwise, return <code>false</code>.
         </li>
       </ol>
+      <div class="note" title="Scope is a simple string match">
+        The URL string matching in this algorithm is prefix-based rather than
+        path-structural (e.g. a target URL string
+        <code>/prefix-of/resource.html</code> will match an app with scope
+        <code>/prefix</code>, even though the path segment name is not an exact
+        match). This is intentional for consistency with <a data-cite=
+        "!SERVICE-WORKERS-1#scope-match-algorithm">Service Workers</a>. To
+        avoid unexpected behavior, use a scope ending in a <code>/</code>.
+      </div>
       <div class="issue" title="🐒 patch">
         <p>
           Enforcing the navigation scope depends on [[!HTML]]'s navigate

--- a/index.html
+++ b/index.html
@@ -775,9 +775,17 @@ window.addEventListener("appinstalled", handleInstalled);
         <li>Let <var>target</var> be a new URL using <var>targetURL</var> as
         input. If <var>target</var> is failure, return <code>false</code>.
         </li>
+        <li>Let <var>scopePath</var> be the elements of <var>scopes</var>'s
+        <a data-cite="!WHATWG-URL#concept-url-path">path</a>, separated by
+        U+002F (/).
+        </li>
+        <li>Let <var>targetPath</var> be the elements of <var>target</var>'s
+        <a data-cite="!WHATWG-URL#concept-url-path">path</a>, separated by
+        U+002F (/).
+        </li>
         <li>If <var>target</var> is <a>same origin</a> as <var>scope</var> and
-        <var>target</var>'s <code>pathname</code> starts with
-        <var>scope</var>'s <code>pathname</code>, return <code>true</code>.
+        <var>targetPath</var> starts with <var>scopePath</var>, return
+        <code>true</code>.
         </li>
         <li>Otherwise, return <code>false</code>.
         </li>


### PR DESCRIPTION
Fixes the definition of path matching (does not change behaviour) and adds an explanation.

Closes #554.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/mgiuca/manifest/scope-matching-fix.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/manifest/9b87698...mgiuca:353336c.html)