### PR TITLE
Fix a typo in “8. Manifest and its members ”

### DIFF
--- a/index.html
+++ b/index.html
@@ -1588,7 +1588,7 @@ Content-Type: application/manifest+json
         as well as how their values are processed.
       </p>
       <p>
-        Every manifest has an associated <dfn>manifest URL</dfn>, which the
+        Every manifest has an associated <dfn>manifest URL</dfn>, which is the
         [[!WHATWG-URL]] from which the <a>manifest</a> was fetched.
       </p>
       <section>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rdeltour/manifest/patch-1.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/manifest/effbdc3...rdeltour:1e2f8ba.html)