### PR TITLE
Update link destination for Trim( ) definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -3652,12 +3652,6 @@
         notation are defined in [[!ECMASCRIPT]].
       </p>
       <p>
-        When instructed to <dfn>Trim</dfn>(<var>x</var>), a user agent MUST
-        behave as if [[!ECMASCRIPT]]'s <a data-cite=
-        "!ECMASCRIPT#sec-string.prototype.trim">String.prototype.trim()</a>
-        function had been called on the string <var>x</var>.
-      </p>
-      <p>
         As the manifest uses the JSON format, this specification relies on the
         types defined in [[!ECMA-404]] specification: namely <dfn>object</dfn>,
         <dfn>array</dfn>, <dfn>number</dfn>, <dfn>string</dfn>,
@@ -3719,6 +3713,14 @@
         "https://www.ecma-international.org/ecma-402/1.0/#sec-6.2.3"><dfn>CanonicalizeLanguageTag</dfn></a>
         abstract operations are defined in [[!ECMAS-402]].
       </p>
+      <p>
+        The following are defined in [[!ECMASCRIPT]]:
+      </p>
+      <ul>
+        <li>
+          <a href="https://www.ecma-international.org/ecma-262/8.0/index.html#sec-string.prototype.trim"><dfn>Trim</dfn></a>
+        </li>
+      </ul>
       <p>
         The following are defined in [[!WEBIDL]]:
       </p>


### PR DESCRIPTION
This moves the reference from a paragraph to be more consistent with other references 

This was craeted per discussion with @KenChris on PR #598, but I'm not sure if this is what was intended.

Signed-off-by: Rob Dolin <robdolin@microsoft.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/manifest/RobDolinMS-trim-definition.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/manifest/797c5b1...b70522a.html)