### PR TITLE
Adding Edge & WebKit implementation status links

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,9 @@
         }, {
           value: "Blink",
           href: "https://code.google.com/p/chromium/issues/detail?id=366145"
+        }, {
+          value: "EdgeHTML",
+          href: "https://developer.microsoft.com/en-us/microsoft-edge/platform/status/webapplicationmanifest/"
         }]
       }],
       issueBase: "https://www.github.com/w3c/manifest/issues/",

--- a/index.html
+++ b/index.html
@@ -69,6 +69,9 @@
         }, {
           value: "EdgeHTML",
           href: "https://developer.microsoft.com/en-us/microsoft-edge/platform/status/webapplicationmanifest/"
+        }, {
+          value: "WebKit",
+          href: "https://webkit.org/status/#specification-web-app-manifest"
         }]
       }],
       issueBase: "https://www.github.com/w3c/manifest/issues/",

--- a/index.html
+++ b/index.html
@@ -61,14 +61,14 @@
       }, {
         key: "Implementation status",
         data: [{
-          value: "Gecko",
-          href: "https://bugzilla.mozilla.org/show_bug.cgi?id=997779"
-        }, {
           value: "Blink",
           href: "https://code.google.com/p/chromium/issues/detail?id=366145"
         }, {
           value: "EdgeHTML",
           href: "https://developer.microsoft.com/en-us/microsoft-edge/platform/status/webapplicationmanifest/"
+        }, {
+          value: "Gecko",
+          href: "https://bugzilla.mozilla.org/show_bug.cgi?id=997779"
         }, {
           value: "WebKit",
           href: "https://webkit.org/status/#specification-web-app-manifest"


### PR DESCRIPTION
I also alphabetized the links.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/aarongustafson/manifest/adding-edge-implementation-status.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/manifest/9642178...aarongustafson:6561007.html)