### PR TITLE
Add payment handler installation URL.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1551,6 +1551,7 @@
              sequence&lt;USVString&gt; categories;
              DOMString iarc_rating_id;
              USVString start_url;
+             USVString payment_handler_install_url;
              DisplayModeType display = "browser";
              OrientationLockType orientation;
              USVString theme_color;
@@ -2020,6 +2021,28 @@
             necessary, modify the <a>start URL</a> of an application.
           </p>
         </section>
+      </section>
+      <section>
+        <h3>
+          <code>payment_handler_install_url</code> member
+        </h3>
+        <p>
+          The <dfn>payment_handler_install_url</dfn> member is a <a>string</a>
+          that represents the <dfn>installation URL for a payment
+          handler</dfn>, which is the <a>URL</a> that the developer would
+          prefer the user agent to load in order to install the
+          [[!payment-handler]] of this web application.
+        </p>
+        <p>
+          The <code>payment_handler_install_url</code> is purely advisory. The
+          user agent MAY <a>ignore</a> it or provide the end-user the choice
+          not to make use of it.
+        </p>
+        <p>
+          The steps for <dfn>processing the
+          <code>payment_handler_install_url</code> member</dfn> are identical
+          to the steps for <a>processing the <code>start_url</code> member</a>.
+        </p>
       </section>
       <section>
         <h3>


### PR DESCRIPTION
This patch adds a `payment_handler_install_url` to the webapp manifest. A user agent may use this URL for just-in-time installation of a payment handler as described in https://github.com/w3c/payment-handler/issues/240.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rsolomakhin/manifest/pull/634.html" title="Last updated on Jan 3, 2018, 3:27 PM GMT (54099e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/634/0707d4a...rsolomakhin:54099e4.html" title="Last updated on Jan 3, 2018, 3:27 PM GMT (54099e4)">Diff</a>