### PR TITLE
Explicitly block opaque origins from requesting manifests

### DIFF
--- a/index.html
+++ b/index.html
@@ -3206,10 +3206,8 @@
           context</dfn></a>
         </li>
         <li>
-          <a href="
-          https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque">
           <dfn data-cite="!HTML/multipage/origin.html#concept-origin-opaque">
-          opaque origin</dfn></a>
+          opaque origin</dfn>
         </li>
         <li>
           <a href=

--- a/index.html
+++ b/index.html
@@ -3208,7 +3208,8 @@
         <li>
           <a href="
           https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque">
-            <dfn data-lt="opaque origin">opaque origin</dfn></a>
+          <dfn data-cite="!HTML/multipage/origin.html#concept-origin-opaque">
+          opaque origin</dfn></a>
         </li>
         <li>
           <a href=

--- a/index.html
+++ b/index.html
@@ -3206,7 +3206,7 @@
           context</dfn></a>
         </li>
         <li>
-          <dfn data-cite="!HTML/multipage/origin.html#concept-origin-opaque">
+          <dfn data-cite="!HTML/origin.html#concept-origin-opaque">
           opaque origin</dfn>
         </li>
         <li>

--- a/index.html
+++ b/index.html
@@ -1270,9 +1270,13 @@
         </p>
         <ol>
           <li>From the <code>Document</code> of the <a>top-level browsing
-          context</a>, let <var>manifest link</var> be the first
+          context</a>, let <var>origin</var> be the <code>Document</code>'s
+          origin, and <var>manifest link</var> be the first 
           <a><code>link</code> element</a> in <a>tree order</a> whose <a><code>
             rel</code> attribute</a> contains the token <code>manifest</code>.
+          </li>
+          <li>If <var>origin</var> is an [[!HTML]] <a>opaque origin</a>,
+          terminate this algorithm.
           </li>
           <li>If <var>manifest link</var> is <code>null</code>, terminate this
           algorithm.
@@ -3200,6 +3204,11 @@
           "https://www.whatwg.org/specs/web-apps/current-work/#top-level-browsing-context">
           <dfn data-lt="top-level browsing contexts">top-level browsing
           context</dfn></a>
+        </li>
+        <li>
+          <a href="
+          https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque">
+            <dfn data-lt="opaque origin">opaque origin</dfn></a>
         </li>
         <li>
           <a href=


### PR DESCRIPTION
This spec change explicitly fails the process of obtaining a manifest if the Document has an opaque origin (i.e. it is sandboxed away from its usual origin).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/638.html" title="Last updated on Jan 18, 2018, 5:13 AM GMT (7c545f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/638/e9185f8...7c545f8.html" title="Last updated on Jan 18, 2018, 5:13 AM GMT (7c545f8)">Diff</a>