### PR TITLE
[Breaking] "scope" member now defaults to parent of "start_url"

### DIFF
--- a/index.html
+++ b/index.html
@@ -747,6 +747,23 @@
         manifest is <a>applied</a>. The <a>navigation scope</a> of a manifest
         <var>manifest</var> is <var>manifest</var>["<a>scope</a>"].
       </p>
+      <div class="note" data-link-for="WebAppManifest">
+        <p>
+          If the <a>scope</a> member is not present in the manifest, it
+          defaults to the directory containing the <a>start_url</a> member. For
+          example, if <a>start_url</a> is <code>/pages/welcome.html</code>, and
+          <a>scope</a> is missing, the navigation scope will be
+          <code>/pages/</code> on the same origin. If <a>start_url</a> is
+          <code>/pages/</code> (the trailing slash is important!), the
+          navigation scope will be <code>/pages/</code>.
+        </p>
+        <p>
+          Developers should take care, if they rely on the default behaviour,
+          that all of the application's pages are in the same directory (or a
+          subdirectory) as the start URL. To be safe, explicitly specify
+          <a>scope</a>.
+        </p>
+      </div>
       <p>
         A string <var>targetURL</var> is said to be <dfn>within scope</dfn> of
         <a>navigation scope</a> <var>scopeURL</var> if the following algorithm
@@ -799,10 +816,6 @@
         scope</a> of the navigation scope of the application context's
         manifest, abort HTML's navigation algorithm with a
         <code>SecurityError</code>.
-      </p>
-      <p class="note" data-link-for="WebAppManifest">
-        A developer specifies the navigation scope via the <a>scope</a> member
-        (defaulting to the parent path of the <a>start_url</a> member).
       </p>
       <section data-link-for="DisplayModeType">
         <h3 id="navigation-scope-security-considerations">

--- a/index.html
+++ b/index.html
@@ -1762,12 +1762,14 @@
           given by the following algorithm. The algorithm takes a
           <a>USVString</a> <var>value</var>, a <a>URL</a> <var>manifest
           URL</var>, a <a>URL</a> <var>document URL</var>, and a URL <var>start
-          URL</var>. This algorithm returns a <a>URL</a> or
-          <code>undefined</code>.
+          URL</var>. This algorithm returns a <a>URL</a>.
         </p>
         <ol>
+          <li>Let <var>default</var> be a new <a>URL</a> using "." as
+          <var>input</var> and <var>start URL</var> as the <var>base</var> URL.
+          </li>
           <li>If <var>value</var> is the empty string, then return
-          <code>undefined</code>.
+          <var>default</var>.
           </li>
           <li>Let <var>scope URL</var> be a new <a>URL</a> using
           <var>value</var> as <var>input</var> and <var>manifest URL</var> as
@@ -1778,7 +1780,7 @@
               <li>
                 <a>Issue a developer warning</a>.
               </li>
-              <li>Return <code>undefined</code>.
+              <li>Return <var>default</var>.
               </li>
             </ul>
           </li>
@@ -1793,7 +1795,7 @@
                 same-origin</a> as <code>Document</code> of the <a>application
                 context</a>.
               </li>
-              <li>Return <code>undefined</code>.
+              <li>Return <var>default</var>.
               </li>
             </ol>
           </li>
@@ -1803,13 +1805,18 @@
                 <a>Issue a developer warning</a> that the start URL is not
                 <a>within scope</a> of the scope URL.
               </li>
-              <li>Return <code>undefined</code>.
+              <li>Return <var>default</var>.
               </li>
             </ol>
           </li>
           <li>Otherwise, return <var>scope URL</var>.
           </li>
         </ol>
+        <div class="note">
+          The default scope (if <code>scope</code> is omitted or an error) is
+          the <var>start URL</var>, with its filename, query, and fragment
+          removed.
+        </div>
       </section>
       <section>
         <h3>

--- a/index.html
+++ b/index.html
@@ -745,9 +745,7 @@
         A <dfn>navigation scope</dfn> is a [[!URL]] that represents the set of
         URLs to which an <a>application context</a> can be navigated while the
         manifest is <a>applied</a>. The <a>navigation scope</a> of a manifest
-        <var>manifest</var> is <var>manifest</var>["<a>scope</a>"]. If this is
-        <code>undefined</code> (due to an error, or because it was not declared
-        in the manifest), the navigation scope is <dfn>unbounded</dfn>.
+        <var>manifest</var> is <var>manifest</var>["<a>scope</a>"].
       </p>
       <p>
         A string <var>targetURL</var> is said to be <dfn>within scope</dfn> of
@@ -755,9 +753,6 @@
         returns <code>true</code>:
       </p>
       <ol>
-        <li>If <var>scopeURL</var> is <code>undefined</code> (i.e., it is
-        <a>unbounded</a>), return <code>true</code>.
-        </li>
         <li>Let <var>target</var> be a new URL using <var>targetURL</var> as
         input. If <var>target</var> is failure, return <code>false</code>.
         </li>
@@ -806,45 +801,20 @@
         <code>SecurityError</code>.
       </p>
       <p class="note" data-link-for="WebAppManifest">
-        A developer specifies the navigation scope via the <a>scope</a> member.
-        In the case where the <a>scope</a> member is missing or in error, the
-        navigation scope is treated as <a>unbounded</a> (represented as the
-        value <code>undefined</code>). In such a case, the manifest is applied
-        to all URLs the application context is <a>navigated</a> to (see related
-        <a href="#navigation-scope-security-considerations">security
-        considerations</a>).
+        A developer specifies the navigation scope via the <a>scope</a> member
+        (defaulting to the parent path of the <a>start_url</a> member).
       </p>
       <section data-link-for="DisplayModeType">
         <h3 id="navigation-scope-security-considerations">
           Security considerations
         </h3>
         <p>
-          When the navigation scope is <a>unbounded</a> and a <a>display
-          mode</a> other than <code>browser</code> is being applied, it is
-          RECOMMENDED that user agents signal to the end-user when security
-          and/or privacy sensitive navigations occur. The manner of signaling
-          is left up to implementers, but can include things like showing the
-          URL of the application context, dropping out of fullscreen to the
-          <a>browser</a> <a>display mode</a>. Examples of security and/or
-          privacy sensitive navigations include, but are not limited to:
-        </p>
-        <ul>
-          <li>the application context being <a>navigated</a> from a secure
-          connection to an insecure connection (or vice versa).
-          </li>
-          <li>the application context being <a>navigated</a> to a different
-          origin.
-          </li>
-        </ul>
-        <p>
-          This specification distinguishes between behavior in first-party and
-          third-party contexts. In particular, if a <code>scope</code> member
-          is declared in the manifest, it is not possible to navigate the
-          <a>top-level browsing context</a> to somewhere outside the scope
-          while the <a>manifest</a> is <a>applied</a> to the <a>top-level
-          browsing context</a>. That's not to say that the web application
-          cannot be navigated: just that the set of URLs to which the manifest
-          applies is restricted by the <a>navigation scope</a>.
+          It should not be possible to navigate the <a>top-level browsing
+          context</a> to somewhere outside the scope while the <a>manifest</a>
+          is <a>applied</a> to the <a>top-level browsing context</a>. That's
+          not to say that the web application cannot be navigated: just that
+          the set of URLs to which the manifest applies is restricted by the
+          <a>navigation scope</a>.
         </p>
       </section>
       <section>
@@ -1147,15 +1117,6 @@
             application. An attacker could, in such a case, exploit the fact
             that an application is being displayed in fullscreen to mimic the
             user interface of another application.
-          </p>
-          <p>
-            Furthermore, by neglecting to define a scope member in the
-            manifest, it's possible to put a web application into a <a>display
-            mode</a> that persists cross-origin (for legacy reasons, this is
-            the default behavior). In case where the navigation scope is
-            unbounded, it is left to the user agent to either stop applying the
-            manifest when a cross-origin navigation occurs or to show some sort
-            of security warning to the user.
           </p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
       <div class="note" data-link-for="WebAppManifest">
         <p>
           If the <a>scope</a> member is not present in the manifest, it
-          defaults to the directory containing the <a>start_url</a> member. For
+          defaults to the parent path of the <a>start_url</a> member. For
           example, if <a>start_url</a> is <code>/pages/welcome.html</code>, and
           <a>scope</a> is missing, the navigation scope will be
           <code>/pages/</code> on the same origin. If <a>start_url</a> is
@@ -759,9 +759,8 @@
         </p>
         <p>
           Developers should take care, if they rely on the default behaviour,
-          that all of the application's pages are in the same directory (or a
-          subdirectory) as the start URL. To be safe, explicitly specify
-          <a>scope</a>.
+          that all of the application's page URLs begin with the parent path of
+          the start URL. To be safe, explicitly specify <a>scope</a>.
         </p>
       </div>
       <p>


### PR DESCRIPTION
This removes the concept of "unbounded scope", which was special behavior if "scope" was omitted. Now, if "scope" is omitted, it defaults to the parent directory of "start_url", which is the most sensible default.

This is a breaking normative change. Sites relying on the old behavior may find that the scope is now more restrictive. In particular, if the "start_url" is deep within the path hierarchy, the rest of the site may no longer be considered part of the app. Having said that, a major implementation (Chrome for Android) already had this policy, so this is expected to bring the spec in-line with current expectations, rather than break existing sites.

Closes #550.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/647.html" title="Last updated on Jan 31, 2018, 5:02 AM GMT (a665904)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/647/326c22e...mgiuca:a665904.html" title="Last updated on Jan 31, 2018, 5:02 AM GMT (a665904)">Diff</a>