### PR TITLE
Change the default value for start_url

### DIFF
--- a/index.html
+++ b/index.html
@@ -805,7 +805,9 @@
           <a>scope</a> is missing, the navigation scope will be
           <code>/pages/</code> on the same origin. If <a>start_url</a> is
           <code>/pages/</code> (the trailing slash is important!), the
-          navigation scope will be <code>/pages/</code>.
+          navigation scope will be <code>/pages/</code>. If both
+          <a>start_url</a> and <a>scope</a> are missing, they will both default
+          to the parent path of the manifest URL.
         </p>
         <p>
           Developers should take care, if they rely on the default behaviour,
@@ -2015,9 +2017,18 @@
           </li>
         </ol>
         <div class="note">
-          The default start URL (if <code>start_url</code> is omitted or an
-          error) is the <var>manifest URL</var>, with its filename, query, and
-          fragment removed.
+          <p>
+            The default start URL (if <code>start_url</code> is omitted or an
+            error) is the <var>manifest URL</var>, with its filename, query,
+            and fragment removed.
+          </p>
+          <p>
+            This default was changed in June 2018. Manifest authors might wish
+            to avoid relying on the default behaviour (and explicitly specify
+            this member), as user agents might still respect the previous
+            default (the document URL), or ignore the manifest entirely if
+            <a>start_url</a> is missing.
+          </p>
         </div>
         <div class="example">
           <p>

--- a/index.html
+++ b/index.html
@@ -1341,6 +1341,15 @@
           <li>Return <var>manifest</var> and <var>manifest URL</var>.
           </li>
         </ol>
+        <p class="issue">
+          There is currently no specified way to obtain a manifest without an
+          associated <a>top-level browsing context</a>. However, several user
+          agents do just that (when they install a web application directly
+          from a manifest URL, without a document). This algorithm, and the
+          <a>steps to install the web application</a>, should similarly be
+          written to not require a document. See <a href=
+          "https://github.com/w3c/manifest/issues/668">#668</a>.
+        </p>
         <div class="note">
           <p>
             Authors are encouraged to use the HTTP cache directives to
@@ -1432,14 +1441,6 @@
           location of the manifest, and an optional <a>URL</a> <var>document
           URL</var>. The output from inputting an JSON document into this
           algorithm is a <dfn>processed manifest</dfn>.
-        </p>
-        <p class="issue">
-          There is currently no way to invoke this algorithm without a
-          <var>document URL</var>. However, several user agents do just that
-          (when they install a web application directly from a manifest URL,
-          without a document). The algorithms that invoke this one should
-          similarly be written to not require a <var>document URL</var>. See
-          <a href="https://github.com/w3c/manifest/issues/668">#668</a>.
         </p>
         <p class="issue">
           We need to catch throws associated with enumerations in IDL

--- a/index.html
+++ b/index.html
@@ -1803,13 +1803,13 @@
           <var>base</var> URL.
           </li>
           <li>If <var>scope URL</var> is failure:
-            <ul>
+            <ol>
               <li>
                 <a>Issue a developer warning</a>.
               </li>
               <li>Return <var>default</var>.
               </li>
-            </ul>
+            </ol>
           </li>
           <li>If <var>start URL</var> is not <a>within scope</a> of scope URL:
             <ol>
@@ -1993,13 +1993,13 @@
           <var>base</var> URL.
           </li>
           <li>If <var>start URL</var> is failure:
-            <ul>
+            <ol>
               <li>
                 <a>Issue a developer warning</a>.
               </li>
               <li>Return <var>default</var>.
               </li>
-            </ul>
+            </ol>
           </li>
           <li>If <var>start URL</var> is not <a>same origin</a> as
           <var>document URL</var>:

--- a/index.html
+++ b/index.html
@@ -1434,6 +1434,14 @@
           algorithm is a <dfn>processed manifest</dfn>.
         </p>
         <p class="issue">
+          There is currently no way to invoke this algorithm without a
+          <var>document URL</var>. However, several user agents do just that
+          (when they install a web application directly from a manifest URL,
+          without a document). The algorithms that invoke this one should
+          similarly be written to not require a <var>document URL</var>. See
+          <a href="https://github.com/w3c/manifest/issues/668">#668</a>.
+        </p>
+        <p class="issue">
           We need to catch throws associated with enumerations in IDL
           conversion as the spec might gain new values over time not supported
           by all exising browsers. This is especially important as we rely on

--- a/index.html
+++ b/index.html
@@ -1429,9 +1429,9 @@
           following algorithm. The algorithm takes a <a>string</a>
           <var>text</var> as an argument, which represents a <a>manifest</a>,
           and a <a>URL</a> <var>manifest URL</var>, which represents the
-          location of the manifest, and a <a>URL</a> <var>document URL</var>.
-          The output from inputting an JSON document into this algorithm is a
-          <dfn>processed manifest</dfn>.
+          location of the manifest, and an optional <a>URL</a> <var>document
+          URL</var>. The output from inputting an JSON document into this
+          algorithm is a <dfn>processed manifest</dfn>.
         </p>
         <p class="issue">
           We need to catch throws associated with enumerations in IDL
@@ -1979,15 +1979,16 @@
           The steps for <dfn>processing the <code>start_url</code> member</dfn>
           are given by the following algorithm. The algorithm takes a
           <a>USVString</a> <var>value</var>, a <a>URL</a> <var>manifest
-          URL</var>, and a <a>URL</a> <var>document URL</var>. This algorithm
-          returns a <a>URL</a>.
+          URL</var>, and an optional <a>URL</a> <var>document URL</var>. This
+          algorithm returns a <a>URL</a>.
         </p>
         <ol>
-          <li>If <var>manifest URL</var> is <a>same origin</a> as <var>document
-          URL</var>, let <var>default</var> be the result of <a>parsing</a>
-          ".", using <var>manifest URL</var> as the <var>base</var> URL.
+          <li>If <var>document URL</var> is given, and <var>manifest URL</var>
+          is not <a>same origin</a> as <var>document URL</var>, let
+          <var>default</var> be <var>document URL</var>.
           </li>
-          <li>Otherwise, let <var>default</var> be <var>document URL</var>.
+          <li>Otherwise, let <var>default</var> be the result of <a>parsing</a>
+          ".", using <var>manifest URL</var> as the <var>base</var> URL.
           </li>
           <li>If <var>value</var> is the empty <a>string</a>, return
           <var>default</var>.
@@ -2005,8 +2006,8 @@
               </li>
             </ol>
           </li>
-          <li>If <var>start URL</var> is not <a>same origin</a> as
-          <var>document URL</var>:
+          <li>If <var>document URL</var> is given, and <var>start URL</var> is
+          not <a>same origin</a> as <var>document URL</var>:
             <ol>
               <li>
                 <a>Issue a developer warning</a> that the <a>start_url</a>

--- a/index.html
+++ b/index.html
@@ -2014,6 +2014,11 @@
           <li>Otherwise, return <var>start URL</var>.
           </li>
         </ol>
+        <div class="note">
+          The default start URL (if <code>start_url</code> is omitted or an
+          error) is the <var>manifest URL</var>, with its filename, query, and
+          fragment removed.
+        </div>
         <div class="example">
           <p>
             For example, if the value of <a>start_url</a> is

--- a/index.html
+++ b/index.html
@@ -1980,8 +1980,11 @@
           returns a <a>URL</a>.
         </p>
         <ol>
+          <li>Let <var>default</var> be the result of <a>parsing</a> ".", using
+          <var>manifest URL</var> as the <var>base</var> URL.
+          </li>
           <li>If <var>value</var> is the empty <a>string</a>, return
-          <var>document URL</var>.
+          <var>default</var>.
           </li>
           <li>Let <var>start URL</var> be the result of <a>parsing</a>
           <var>value</var>, using <var>manifest URL</var> as the
@@ -1992,7 +1995,7 @@
               <li>
                 <a>Issue a developer warning</a>.
               </li>
-              <li>Return <var>document URL</var>.
+              <li>Return <var>default</var>.
               </li>
             </ul>
           </li>
@@ -2004,7 +2007,7 @@
                 needs to be <a>same-origin</a> as <code>Document</code> of the
                 <a>top-level browsing context</a>.
               </li>
-              <li>Return <var>document URL</var>.
+              <li>Return <var>default</var>.
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -807,7 +807,8 @@
           <code>/pages/</code> (the trailing slash is important!), the
           navigation scope will be <code>/pages/</code>. If both
           <a>start_url</a> and <a>scope</a> are missing, they will both default
-          to the parent path of the manifest URL.
+          to the parent path of the manifest URL (assuming it is
+          <a>same-origin</a> as the document that referenced it).
         </p>
         <p>
           Developers should take care, if they rely on the default behaviour,
@@ -1982,8 +1983,11 @@
           returns a <a>URL</a>.
         </p>
         <ol>
-          <li>Let <var>default</var> be the result of <a>parsing</a> ".", using
-          <var>manifest URL</var> as the <var>base</var> URL.
+          <li>If <var>manifest URL</var> is <a>same origin</a> as <var>document
+          URL</var>, let <var>default</var> be the result of <a>parsing</a>
+          ".", using <var>manifest URL</var> as the <var>base</var> URL.
+          </li>
+          <li>Otherwise, let <var>default</var> be <var>document URL</var>.
           </li>
           <li>If <var>value</var> is the empty <a>string</a>, return
           <var>default</var>.
@@ -2028,6 +2032,10 @@
             this member), as user agents might still respect the previous
             default (the document URL), or ignore the manifest entirely if
             <a>start_url</a> is missing.
+          </p>
+          <p>
+            This doesn't apply if the manifest is not <a>same-origin</a> as the
+            document that referenced it.
           </p>
         </div>
         <div class="example">


### PR DESCRIPTION
Breaking: Changed the default start_url to the parent path of the manifest.

Previously, it defaulted to the document URL, which was not stable (the same manifest produces different results in different contexts) and is not guaranteed to exist.

This also makes the document URL optional for the "processing the manifest" algorithm, since it is now only used to check that the document and start_url are same origin.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/670.html" title="Last updated on Jul 9, 2018, 6:59 AM GMT (481f44b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/670/cc53c75...mgiuca:481f44b.html" title="Last updated on Jul 9, 2018, 6:59 AM GMT (481f44b)">Diff</a>