### PR TITLE
Editorial fix to the `orientation` member

### DIFF
--- a/index.html
+++ b/index.html
@@ -3548,8 +3548,8 @@
               orientation</dfn>
             </li>
             <li>
-              <a data-cite=
-              "!SCREEN-ORIENTATION#dom-orientationlocktype"><dfn>OrientationLockType</dfn></a>
+              <dfn data-cite=
+              "!SCREEN-ORIENTATION#dom-orientationlocktype">OrientationLockType</dfn>
             </li>
           </ul>
         </li>

--- a/index.html
+++ b/index.html
@@ -1909,7 +1909,7 @@
         <p>
           Certain UI/UX concerns and/or platform conventions will mean that
           some screen orientations and display modes <dfn>cannot be used
-          together</dfn> . Which orientations and display modes cannot be used
+          together</dfn>. Which orientations and display modes cannot be used
           together is left to the discretion of implementers. For example, for
           some user agents, it might not make sense to change the <a>default
           orientation</a> of an application while in <code>browser</code>
@@ -3549,7 +3549,7 @@
             </li>
             <li>
               <a data-cite=
-              "!SCREEN-ORIENTATION#idl-def-OrientationLockType"><dfn>OrientationLockType</dfn></a>
+              "!SCREEN-ORIENTATION#dom-orientationlocktype"><dfn>OrientationLockType</dfn></a>
             </li>
           </ul>
         </li>

--- a/index.html
+++ b/index.html
@@ -3543,9 +3543,9 @@
         <li>[[!SCREEN-ORIENTATION]] defines the following terms:
           <ul>
             <li>
-              <a data-cite=
-              "!SCREEN-ORIENTATION#dfn-default-orientation"><dfn>default
-              orientation</dfn></a>
+              <dfn data-cite=
+              "!SCREEN-ORIENTATION#dfn-default-orientation">default
+              orientation</dfn>
             </li>
             <li>
               <a data-cite=


### PR DESCRIPTION
* Fix the URL of `OrientationLockType`
* Remove an extra space


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/672.html" title="Last updated on May 8, 2018, 2:50 AM GMT (f7e41be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/672/8c7fb60...f7e41be.html" title="Last updated on May 8, 2018, 2:50 AM GMT (f7e41be)">Diff</a>