### PR TITLE
Fix some text relating to fullscreen display mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -992,12 +992,11 @@
           Privacy and security considerations
         </h3>
         <p>
-          When the <a>fullscreen</a> <a>display mode</a> is applied, it is
-          RECOMMENDED that the user agent provides the end-user a means to
-          consult common information about the web application, such as the
-          origin, start and/or current URL, granted permissions, and associated
-          icon. How such information is exposed to end-users is left up to
-          implementers.
+          When the web application is running, it is RECOMMENDED that the user
+          agent provides the end-user a means to consult common information
+          about the web application, such as the origin, start and/or current
+          URL, granted permissions, and associated icon. How such information
+          is exposed to end-users is left up to implementers.
         </p>
         <p>
           Additionally, when applying a manifest that sets the <a>display

--- a/index.html
+++ b/index.html
@@ -993,7 +993,7 @@
         </h3>
         <p>
           When the web application is running, it is RECOMMENDED that the user
-          agent provides the end-user a means to consult common information
+          agent provides the end-user a means to access common information
           about the web application, such as the origin, start and/or current
           URL, granted permissions, and associated icon. How such information
           is exposed to end-users is left up to implementers.

--- a/index.html
+++ b/index.html
@@ -952,7 +952,7 @@
           <dfn>minimal-ui</dfn>
         </dt>
         <dd>
-          This mode is similar to <a>fullscreen</a>, but provides the end-user
+          This mode is similar to <a>standalone</a>, but provides the end-user
           with some means to access a minimal set of UI elements for
           controlling navigation (i.e., back, forward, reload, and perhaps some
           way of viewing the document's address). A user agent can include


### PR DESCRIPTION
* Remove qualification on recommendation to show security info. Previously only
  applied to fullscreen display mode; now applies to all.
* display: minimal-ui is based on standalone.

Closes #677.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/679.html" title="Last updated on May 23, 2018, 1:05 AM GMT (7d8e1c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/679/ae34b01...mgiuca:7d8e1c7.html" title="Last updated on May 23, 2018, 1:05 AM GMT (7d8e1c7)">Diff</a>