### PR TITLE
editorial: fix a broken local reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,9 +67,6 @@
         }]
       }],
       github: "https://github.com/w3c/manifest/",
-      lint: {
-        "local-refs-exist": true,
-      },
     };
     </script>
   </head>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@
         </table>
         <p>
           The <a>media type for a manifest</a> serves as the default media type
-          for resources associated with the <code><a>manifest</a></code>
+          for resources associated with the "<code>manifest</code>"
           <a>link type</a>.
         </p>
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -68,9 +68,6 @@
       }],
       github: "https://github.com/w3c/manifest/",
       lint: {
-        "no-headingless-sections": true,
-        "privsec-section": true,
-        "no-http-props": true,
         "local-refs-exist": true,
       },
     };
@@ -1214,8 +1211,8 @@
         </table>
         <p>
           The <a>media type for a manifest</a> serves as the default media type
-          for resources associated with the "<code>manifest</code>"
-          <a>link type</a>.
+          for resources associated with the "<code>manifest</code>" <a>link
+          type</a>.
         </p>
         <p class="note">
           In cases where more than one <a><code>link</code> element</a> with a

--- a/index.html
+++ b/index.html
@@ -67,6 +67,12 @@
         }]
       }],
       github: "https://github.com/w3c/manifest/",
+      lint: {
+        "no-headingless-sections": true,
+        "privsec-section": true,
+        "no-http-props": true,
+        "local-refs-exist": true,
+      },
     };
     </script>
   </head>
@@ -1208,8 +1214,8 @@
         </table>
         <p>
           The <a>media type for a manifest</a> serves as the default media type
-          for resources associated with the <code><a href=
-          "#rel-manifest">manifest</a></code> <a>link type</a>.
+          for resources associated with the <code><a>manifest</a></code>
+          <a>link type</a>.
         </p>
         <p class="note">
           In cases where more than one <a><code>link</code> element</a> with a


### PR DESCRIPTION
Also enabled [`local-refs-exist` lint rule](https://github.com/w3c/respec/wiki/local-refs-exist) to prevent broken references in future


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sidvishnoi/manifest/pull/682.html" title="Last updated on Jun 22, 2018, 4:22 PM GMT (5fa07f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/682/0997b5a...sidvishnoi:5fa07f0.html" title="Last updated on Jun 22, 2018, 4:22 PM GMT (5fa07f0)">Diff</a>