### PR TITLE
editorial: add browser support table

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
         }]
       }],
       github: "https://github.com/w3c/manifest/",
+      caniuse: "web-app-manifest",
     };
     </script>
   </head>


### PR DESCRIPTION
Adds a browser support table based on data from caniuse.com (Read about this ReSpec feature [here](https://github.com/w3c/respec/wiki/caniuse))

Edit: This feature is only available in "live" Editor's Drafts. You can preview it by adding [`?caniuse=web-app-manifest`](https://w3c.github.io/manifest/?caniuse=web-app-manifest) as a URL parameter


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sidvishnoi/manifest/pull/694.html" title="Last updated on Jun 14, 2018, 8:39 AM GMT (3b7a581)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/694/0997b5a...sidvishnoi:3b7a581.html" title="Last updated on Jun 14, 2018, 8:39 AM GMT (3b7a581)">Diff</a>