### PR TITLE
scope algorithm: Delete same-origin-as-document check.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1445,8 +1445,8 @@
           </li>
           <li>Set <var>manifest</var>["<a>scope</a>"] to the result of running
           <a>processing the <code>scope</code> member</a> given
-          <var>manifest</var>["<a>scope</a>"], <var>manifest URL</var>,
-          <var>document URL</var>, and <var>manifest</var>["<a>start_url</a>"].
+          <var>manifest</var>["<a>scope</a>"], <var>manifest URL</var>, and
+          <var>manifest</var>["<a>start_url</a>"].
           </li>
           <li>Set <var>manifest</var>["<a>theme_color</a>"] to the result of
           running <a>processing the <code>theme_color</code> member</a> given
@@ -1752,8 +1752,8 @@
           The steps for <dfn>processing the <code>scope</code> member</dfn> is
           given by the following algorithm. The algorithm takes a
           <a>USVString</a> <var>value</var>, a <a>URL</a> <var>manifest
-          URL</var>, a <a>URL</a> <var>document URL</var>, and a URL <var>start
-          URL</var>. This algorithm returns a <a>URL</a>.
+          URL</var>, and a URL <var>start URL</var>. This algorithm returns a
+          <a>URL</a>.
         </p>
         <ol>
           <li>Let <var>default</var> be the result of <a>parsing</a> ".", using
@@ -1774,21 +1774,6 @@
               <li>Return <var>default</var>.
               </li>
             </ul>
-          </li>
-          <li>If <var>scope URL</var> is not <a href=
-          "https://www.whatwg.org/specs/web-apps/current-work/#same-origin">same
-          origin</a> as <var>document URL</var>:
-            <ol>
-              <li>
-                <a>Issue a developer warning</a> that the <code>scope</code>
-                needs to be <a href=
-                "https://www.whatwg.org/specs/web-apps/current-work/#same-origin">
-                same-origin</a> as <code>Document</code> of the <a>application
-                context</a>.
-              </li>
-              <li>Return <var>default</var>.
-              </li>
-            </ol>
           </li>
           <li>If <var>start URL</var> is not <a>within scope</a> of scope URL:
             <ol>


### PR DESCRIPTION
This was redundant, because a) the start_url is already checked to be
same-origin-as-document, and b) the start_url is checked to be within
scope of scope (which implies they are same-origin). Thus the scope is
guaranteed to be same-origin as the document without this explicit
check.

This removes the document URL parameter to the scope algorithm.

No normative changes.

Work towards fixing #668.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/696.html" title="Last updated on Jun 15, 2018, 2:48 AM GMT (1c255c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/696/0997b5a...mgiuca:1c255c4.html" title="Last updated on Jun 15, 2018, 2:48 AM GMT (1c255c4)">Diff</a>