### PR TITLE
Add ctor params to BeforeInstallPromptEvent

### DIFF
--- a/index.html
+++ b/index.html
@@ -564,7 +564,8 @@
           historical reasons.
         </div>
         <pre class="idl">
-          [Constructor, Exposed=Window]
+          [Constructor(DOMString type, optional EventInit eventInitDict),
+           Exposed=Window]
           interface BeforeInstallPromptEvent : Event {
               Promise&lt;PromptResponseObject&gt; prompt();
           };


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/pull/11765 introduces a failing test for a scraped copy of the IDL.

> BeforeInstallPromptEvent interface object length
> assert_equals: wrong value for BeforeInstallPromptEvent.length expected 0 but got 1

This changes the ctor to match `Event`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukebjerring/manifest/pull/698.html" title="Last updated on Jul 4, 2018, 1:03 AM GMT (09a4d19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/698/ededb2d...lukebjerring:09a4d19.html" title="Last updated on Jul 4, 2018, 1:03 AM GMT (09a4d19)">Diff</a>