### PR TITLE
Breaking: Change requirement to block off-scope navigation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -818,12 +818,12 @@
         "!HTML#active-document">active document</a>'s <a data-cite=
         "!DOM#concept-document-url">URL</a> is not <a>within scope</a> of the
         navigation scope of the <a>application context</a>'s manifest, the user
-        agent SHOULD show prominent UI indicating the <a data-cite=
+        agent SHOULD show a prominent UI element indicating the <a data-cite=
         "!DOM#concept-document-url">document URL</a>, or at least its
         <a>origin</a>, including whether it is served over a secure connection.
         This UI SHOULD differ from any UI used when the <a data-cite=
         "!DOM#concept-document-url">document URL</a> is <a>within scope</a>, in
-        order to alert the user of the off-scope navigation.
+        order to make it obvious that the user is navigating off scope.
       </p>
       <div class="note">
         <p>
@@ -846,10 +846,10 @@
           Security considerations
         </h3>
         <p>
-          The above recommendation to show UI when the <a>application
-          context</a> is navigated to a <a>URL</a> that is not <a>within
-          scope</a> of the manifest is for security. It ensures that users are
-          always aware of which <a>origin</a> they are interacting with.
+          The above recommendation (to show some UI when the <a>application
+          context</a> is navigated to an out-of-scope <a>URL</a>) is for
+          security reasons. It ensures that users are always aware of which
+          <a>origin</a> they are interacting with.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -836,9 +836,8 @@
           Unlike previous versions of this specification, user agents are no
           longer required or allowed to block off-scope navigations, or open
           them in a new <a>top-level browsing context</a>. This practice broke
-          a lot of sites that navigate to a URL on another origin (e.g., to
-          perform third-party authentication), which would then navigate back
-          to the originating site. See <a href=
+          some sites that navigate to an off-scope URL (e.g., to perform
+          third-party authentication). See <a href=
           "https://github.com/w3c/manifest/issues/646">Issue 646</a>.
         </p>
       </div>

--- a/index.html
+++ b/index.html
@@ -813,50 +813,44 @@
         "!SERVICE-WORKERS-1#scope-match-algorithm">Service Workers</a>. To
         avoid unexpected behavior, use a scope ending in a <code>/</code>.
       </div>
-      <div class="issue" title="🐒 patch">
+      <p>
+        If the <a>application context</a>'s <a data-cite=
+        "!HTML#active-document">active document</a>'s <a data-cite=
+        "!DOM#concept-document-url">URL</a> is not <a>within scope</a> of the
+        navigation scope of the <a>application context</a>'s manifest, the user
+        agent SHOULD show prominent UI indicating the <a data-cite=
+        "!DOM#concept-document-url">document URL</a>, or at least its
+        <a>origin</a>, including whether it is served over a secure connection.
+        This UI SHOULD differ from any UI used when the <a data-cite=
+        "!DOM#concept-document-url">document URL</a> is <a>within scope</a>, in
+        order to alert the user of the off-scope navigation.
+      </p>
+      <div class="note">
         <p>
-          Enforcing the navigation scope depends on [[!HTML]]'s navigate
-          algorithm. As such, the following monkey patches [[!HTML]]. <a href=
-          "https://www.w3.org/Bugs/Public/show_bug.cgi?id=27653">Bug 27653</a>
-          has been filed to address this.
+          Nothing prevents an <a>application context</a> from navigating to a
+          <a>URL</a> that is outside of the application's <a>navigation
+          scope</a>, while still having the <a>manifest</a> <a>applied</a> to
+          it.
+        </p>
+        <p>
+          Unlike previous versions of this specification, user agents are no
+          longer required or allowed to block off-scope navigations, or open
+          them in a new <a>top-level browsing context</a>. This practice broke
+          a lot of sites that navigate to a URL on another origin (e.g., to
+          perform third-party authentication), which would then navigate back
+          to the originating site. See <a href=
+          "https://github.com/w3c/manifest/issues/646">Issue 646</a>.
         </p>
       </div>
-      <p>
-        The [[!HTML]] <a>navigate algorithm</a> is monkey-patched as follows:
-      </p>
-      <ul>
-        <li>After the clause "If the <a data-cite=
-        "!HTML#source-browsing-context">source browsing context</a> is not <a>
-          allowed to navigate</a> <var>browsingContext</var>…", add: "or
-          <var>browsingContext</var> is an <a>application context</a>, and
-          <var>resource</var> is not <a>within scope</a> of the navigation
-          scope of <var>browsingContext</var>'s manifest."
-        </li>
-        <li>If, at any time, an <a>application context</a> is navigated to a
-        <a>URL</a> <var>url</var> that is not <a>within scope</a> of the
-        navigation scope of the context's manifest, abort the navigation, and
-        optionally, <a data-cite="!HTML#creating-a-new-browsing-context">create
-        a new browsing context</a> and <a>navigate</a> it to <var>url</var>.
-        </li>
-      </ul>
-      <p class="note">
-        This prohibits the <a>application context</a> from ever displaying a
-        <a>URL</a> that is outside of the application's <a>navigation
-        scope</a>. However, it provides the ability for the user agent to
-        perform the navigation in a different browsing context, or in a
-        different user agent entirely.
-      </p>
       <section data-link-for="DisplayModeType">
         <h3 id="navigation-scope-security-considerations">
           Security considerations
         </h3>
         <p>
-          It should not be possible to navigate the <a>top-level browsing
-          context</a> to somewhere outside the scope while the <a>manifest</a>
-          is <a>applied</a> to the <a>top-level browsing context</a>. That's
-          not to say that the web application cannot be navigated: just that
-          the set of URLs to which the manifest applies is restricted by the
-          <a>navigation scope</a>.
+          The above recommendation to show UI when the <a>application
+          context</a> is navigated to a <a>URL</a> that is not <a>within
+          scope</a> of the manifest is for security. It ensures that users are
+          always aware of which <a>origin</a> they are interacting with.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -816,24 +816,35 @@
       <div class="issue" title="🐒 patch">
         <p>
           Enforcing the navigation scope depends on [[!HTML]]'s navigate
-          algorithm. As such, the following algorithm monkey patches [[!HTML]].
-          <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=27653">Bug
-          27653</a> has been filed to address this.
+          algorithm. As such, the following monkey patches [[!HTML]]. <a href=
+          "https://www.w3.org/Bugs/Public/show_bug.cgi?id=27653">Bug 27653</a>
+          has been filed to address this.
         </p>
       </div>
       <p>
-        The user agent MUST navigate the application context as per [[!HTML]]'s
-        <a>navigate algorithm</a> with exceptions enabled. If the URL of the
-        resource being loaded in the navigation is not <a>within scope</a> of
-        the navigation scope of the application context's manifest, then the
-        user agent MUST behave as if the application context is not <a>allowed
-        to navigate</a>. This provides the ability for the user agent to
+        The [[!HTML]] <a>navigate algorithm</a> is monkey-patched as follows:
+      </p>
+      <ul>
+        <li>After the clause "If the <a data-cite=
+        "!HTML#source-browsing-context">source browsing context</a> is not <a>
+          allowed to navigate</a> <var>browsingContext</var>…", add: "or
+          <var>browsingContext</var> is an <a>application context</a>, and
+          <var>resource</var> is not <a>within scope</a> of the navigation
+          scope of <var>browsingContext</var>'s manifest."
+        </li>
+        <li>If, at any time, an <a>application context</a> is navigated to a
+        <a>URL</a> <var>url</var> that is not <a>within scope</a> of the
+        navigation scope of the context's manifest, abort the navigation, and
+        optionally, <a data-cite="!HTML#creating-a-new-browsing-context">create
+        a new browsing context</a> and <a>navigate</a> it to <var>url</var>.
+        </li>
+      </ul>
+      <p class="note">
+        This prohibits the <a>application context</a> from ever displaying a
+        <a>URL</a> that is outside of the application's <a>navigation
+        scope</a>. However, it provides the ability for the user agent to
         perform the navigation in a different browsing context, or in a
-        different user agent entirely. If during the handle redirects step of
-        HTML's <a>navigate algorithm</a> the redirect URL is not <a>within
-        scope</a> of the navigation scope of the application context's
-        manifest, abort HTML's navigation algorithm with a
-        <code>SecurityError</code>.
+        different user agent entirely.
       </p>
       <section data-link-for="DisplayModeType">
         <h3 id="navigation-scope-security-considerations">


### PR DESCRIPTION
Previously, user agents were required to prevent off-scope navigation (or open it in a new top-level browsing context). Now, they are not allowed to do this, as it broke existing sites not designed to be run under these conditions.

Replaced with a recommendation to show the URL when off-scope.

Closes #646.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/701.html" title="Last updated on Jul 10, 2018, 3:01 AM GMT (ad78efa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/701/cc53c75...mgiuca:ad78efa.html" title="Last updated on Jul 10, 2018, 3:01 AM GMT (ad78efa)">Diff</a>