### PR TITLE
[chore] tidyconfig: Added explicit indent-spaces.

### DIFF
--- a/tidyconfig.txt
+++ b/tidyconfig.txt
@@ -1,4 +1,5 @@
 char-encoding: utf8
 indent: yes
+indent-spaces: 2
 wrap: 80
 tidy-mark: no


### PR DESCRIPTION
Fixes HTML Tidy, which changed some time in between 5.7.3 and 5.7.16 to not indent unless `indent-spaces: 2` explicitly appears in the config file.

With tidy 5.7.16, running it over the Manifest doc will reset all indentation to 0. With this patch, tidy makes no changes to index.html.

(We discovered this in the Web Share Target repo upon updating Tidy to the latest git 86b52dc1. It's possible this isn't broken in any tidy release, but it's easier to just update the `tidyconfig.txt` than figure out whether this is a bug in tidy or an intended change.)