### PR TITLE
Example 15: Improve description

### DIFF
--- a/index.html
+++ b/index.html
@@ -2540,9 +2540,9 @@
         </ol>
         <div class="example">
           <p>
-            In the following example, the web application is listing two
-            different related applications, one on Google Play Store and the
-            other one on the iTunes Store:
+            In the following example, the web application is listing two icons
+            to be used as a badge, one of which is specifically designed for
+            the Android platform.
           </p>
           <pre class="example json">
             {


### PR DESCRIPTION
The description for example 15 is wrong, as it describes something different compared to what the sample code actually demonstrates. It’s an exact duplicate of the introductory sentence from example 16.

Still, two problems remain:
- [ ] `android` is not defined as a platform [in the wiki](https://github.com/w3c/manifest/wiki/Platforms) (see https://github.com/w3c/manifest/pull/581)
- [ ] Maybe the demo code wants to line out something different (as the second badge icon has the file name `safari.svg`)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/christianliebel/manifest/pull/713.html" title="Last updated on Aug 27, 2018, 6:24 PM GMT (3965c72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/713/60a5156...christianliebel:3965c72.html" title="Last updated on Aug 27, 2018, 6:24 PM GMT (3965c72)">Diff</a>