### PR TITLE
Editorial: Explain reasoning for single IARC code

### DIFF
--- a/index.html
+++ b/index.html
@@ -2310,11 +2310,11 @@
         </p>
         <p class="note">
           Manifest authors can obtain IARC certificates via participating
-          storefronts over which the web application should be distributed.
-          The <dfn>iarc_rating_id</dfn> member only takes a single
-          certification code. The same code can be shared across storefronts,
-          as long as the distributed product remains the same and the other
-          storefronts support it.
+          storefronts over which the web application is distributed. The
+          <dfn>iarc_rating_id</dfn> member only takes a single certification
+          code. The same code can be shared across storefronts, as long as the
+          distributed product remains the same and the other storefronts
+          support it.
         </p>
         <div class="informative">
           <p>

--- a/index.html
+++ b/index.html
@@ -2303,9 +2303,18 @@
         </h3>
         <p>
           The <dfn>iarc_rating_id</dfn> member is a <a>string</a> that
-          represents an ID value of the IARC rating of the web application. It
-          is intended to be used to determine which ages the web application is
-          appropriate for.
+          represents the <a href="https://www.globalratings.com/">International
+          Age Rating Coalition (IARC)</a> certification code of the web
+          application. It is intended to be used to determine which ages the
+          web application is appropriate for.
+        </p>
+        <p class="note">
+          Manifest authors can obtain IARC certificates via participating
+          storefronts over which the web application should be distributed.
+          The <dfn>iarc_rating_id</dfn> member only takes a single
+          certification code. The same code can be shared across storefronts,
+          as long as the distributed product remains the same and the other
+          storefronts support it.
         </p>
         <div class="informative">
           <p>
@@ -2325,9 +2334,7 @@
         </pre>
         </div>
         <p>
-          More information on the <a href=
-          "https://www.globalratings.com/">International Age Rating Coalition
-          (IARC)</a> can be found at: <a href=
+          More information on the IARC can be found at: <a href=
           "https://www.globalratings.com/how-iarc-works.aspx">How IARC
           Works</a> and <a href=
           "https://www.globalratings.com/for-developers.aspx">How developers

--- a/index.html
+++ b/index.html
@@ -2309,12 +2309,13 @@
           web application is appropriate for.
         </p>
         <p class="note">
-          Manifest authors can obtain IARC certificates via participating
-          storefronts over which the web application is distributed. The
+          An IARC certificate can be obtained via participating storefronts,
+          intended to be used for distributing the web app. The
           <dfn>iarc_rating_id</dfn> member only takes a single certification
-          code. The same code can be shared across storefronts, as long as the
-          distributed product remains the same and the other storefronts
-          support it.
+          code. The same code can be shared across participating storefronts,
+          as long as the distributed product remains the same (i.e., doesn’t
+          serve totally different code paths depending on user agent sniffing
+          and the like) and the other storefronts support it.
         </p>
         <div class="informative">
           <p>


### PR DESCRIPTION
@kenchris As discussed in https://github.com/w3c/manifest/issues/712, here’s the pull request that explains the reasoning for the single IARC certification code in the Web App Manifest.

Please let me know if this looks fine. Is it okay to move the IARC hyperlink from the informational section to the top? The hyperlink wouldn’t be ultimately required, but I’d like to explain what IARC stands for right in the first sentence.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/christianliebel/manifest/pull/715.html" title="Last updated on Aug 31, 2018, 8:42 AM GMT (f4f8598)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/715/9a9f3d6...christianliebel:f4f8598.html" title="Last updated on Aug 31, 2018, 8:42 AM GMT (f4f8598)">Diff</a>