### PR TITLE
Editorial: Remove duplicate dfn of iarc_rating_id

### DIFF
--- a/index.html
+++ b/index.html
@@ -2311,11 +2311,11 @@
         <p class="note">
           An IARC certificate can be obtained via participating storefronts,
           intended to be used for distributing the web app. The
-          <dfn>iarc_rating_id</dfn> member only takes a single certification
-          code. The same code can be shared across participating storefronts,
-          as long as the distributed product remains the same (i.e., doesn’t
-          serve totally different code paths depending on user agent sniffing
-          and the like) and the other storefronts support it.
+          <a>iarc_rating_id</a> member only takes a single certification code.
+          The same code can be shared across participating storefronts, as long
+          as the distributed product remains the same (i.e., doesn’t serve
+          totally different code paths depending on user agent sniffing and the
+          like) and the other storefronts support it.
         </p>
         <div class="informative">
           <p>


### PR DESCRIPTION
Fixes the duplicate definition of `iarc_rating_id`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/christianliebel/manifest/pull/718.html" title="Last updated on Sep 3, 2018, 2:19 PM GMT (32ddf3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/718/5fbd52b...christianliebel:32ddf3d.html" title="Last updated on Sep 3, 2018, 2:19 PM GMT (32ddf3d)">Diff</a>