### PR TITLE
Editorial: Add mobile browsers to caniuse block

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,10 @@
         }]
       }],
       github: "https://github.com/w3c/manifest/",
-      caniuse: "web-app-manifest",
+      caniuse: {
+          feature: "web-app-manifest",
+          browsers: ["chrome", "firefox", "safari", "edge", "and_chr", "and_ff", "ios_saf"],
+      },
     };
     </script>
   </head>


### PR DESCRIPTION
Closes #717 

Requires merging https://github.com/w3c/respec/pull/1815 and creating a new ReSpec release first.