### PR TITLE
Deleted repeated "safe" and fixed typo in definition of "safe zone"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2530,7 +2530,7 @@
             <dfn data-lt="badge maskable">maskable</dfn>:
           </dt>
           <dd>
-            The image is designed with <a href="#icon-masks">icon masks and safe
+            The image is designed with <a href="#icon-masks">icon masks and
             safe zone</a> in mind, such that any part of the image that is
             outside the <a>safe zone</a> can safely be ignored and masked
             away by the user agent.
@@ -2625,7 +2625,7 @@
           preferences. It is defined as a circle with center point in the center
           of the icon and with a radius of 2/5 (40%) of the icon size, which means
           the smaller of the icon width and height, in case the icon is not
-          rectangular.
+          square.
         </p>
         <p class="note">
           Designers of <a>maskable</a> icons will want to make sure that all


### PR DESCRIPTION
Closes #???

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative behavior
* [ x ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

The following tasks have been completed:

* [ ] Confirmed there are no new ReSpec errors/warnings.

Commit message:

Deleted repeated "safe" word and fixed typo in definition of "safe zone".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brunogirin/manifest/pull/720.html" title="Last updated on Sep 26, 2018, 9:43 AM GMT (ebe2e92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/720/c8d4b80...brunogirin:ebe2e92.html" title="Last updated on Sep 26, 2018, 9:43 AM GMT (ebe2e92)">Diff</a>