### PR TITLE
Added missing alt attributes to img elements.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2693,7 +2693,8 @@
           </h2>
           <div class="icons">
             <div>
-              <img src="images/icon-plain.svg">
+              <img src="images/icon-plain.svg" alt=
+              "An icon over a checkerboard background">
               <div class="icon-title">
                 Image
               </div>
@@ -2702,7 +2703,8 @@
               </div>
             </div>
             <div>
-              <img src="images/icon-safe-zone.svg">
+              <img src="images/icon-safe-zone.svg" alt=
+              "An icon in a purple circle (40% of the size) over a yellow background">
               <div class="icon-title">
                 Safe zone
               </div>
@@ -2716,7 +2718,8 @@
           </h2>
           <div class="icons">
             <div>
-              <img src="images/icon-mask-android-roundsquare.svg">
+              <img src="images/icon-mask-android-roundsquare.svg" alt=
+              "An icon inside a rounded yellow square on a purple background">
               <div class="icon-title">
                 Rounded square
               </div>
@@ -2725,7 +2728,8 @@
               </div>
             </div>
             <div>
-              <img src="images/icon-mask-android-squircle.svg">
+              <img src="images/icon-mask-android-squircle.svg" alt=
+              "An icon inside an extremely rounded yellow square on a purple background">
               <div class="icon-title">
                 Squircle
               </div>
@@ -2734,7 +2738,8 @@
               </div>
             </div>
             <div>
-              <img src="images/icon-mask-android-circle.svg">
+              <img src="images/icon-mask-android-circle.svg" alt=
+              "An icon inside a rounded yellow circle on a purple background">
               <div class="icon-title">
                 Circle
               </div>
@@ -2743,7 +2748,8 @@
               </div>
             </div>
             <div>
-              <img src="images/icon-mask-ios.svg">
+              <img src="images/icon-mask-ios.svg" alt=
+              "An icon inside a somewhat rounded yellow square on a purple background">
               <div class="icon-title">
                 Rounded square
               </div>
@@ -2752,7 +2758,8 @@
               </div>
             </div>
             <div>
-              <img src="images/icon-mask-windows.svg">
+              <img src="images/icon-mask-windows.svg" alt=
+              "An icon on a yellow background">
               <div class="icon-title">
                 Fullbleed
               </div>


### PR DESCRIPTION
Closes #729

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative behavior
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [X] Is a "chore" (metadata, formatting, fixing warnings, etc).

The following tasks have been completed:

* [ ] Confirmed there are no new ReSpec errors/warnings. (Respec warnings panel seems broken.)

Commit message:

Added missing alt attributes to img elements.

This was blocking W3C autopublish.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/731.html" title="Last updated on Nov 7, 2018, 1:11 AM GMT (aa853e0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/731/f1278b7...mgiuca:aa853e0.html" title="Last updated on Nov 7, 2018, 1:11 AM GMT (aa853e0)">Diff</a>