### PR TITLE
editorial: fix xref to IDL's sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -2181,10 +2181,11 @@
         <p>
           The steps for <dfn>processing the <code>related_applications</code>
           member</dfn> are given by the following algorithm. The algorithm
-          takes a sequence&lt;<a>ExternalApplicationResource</a>&gt;
+          takes a <a data-cite=
+          "WEBIDL#sequence-type">sequence</a>&lt;<a>ExternalApplicationResource</a>&gt;
           <var>related applications</var> as an argument. This algorithm
           returns an <a data-cite=
-          "WEBIDL#sequence">sequence</a>&lt;<a>ExternalApplicationResource</a>&gt;.
+          "WEBIDL#sequence-type">sequence</a>&lt;<a>ExternalApplicationResource</a>&gt;.
         </p>
         <ol>
           <li>Let <var>relatedApplications</var> be a new Array object created


### PR DESCRIPTION
This change (choose one):

* [x] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)

The following tasks have been completed:

* [x] Confirmed there are no new ReSpec errors/warnings.

Commit message:
Fixed a broken and a missing cross reference


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/736.html" title="Last updated on Nov 12, 2018, 4:22 AM GMT (a1c701e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/736/16c5d13...a1c701e.html" title="Last updated on Nov 12, 2018, 4:22 AM GMT (a1c701e)">Diff</a>