### PR TITLE
chore(.travis): check spec for errors/warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+node_js:
+  - lts/*
 
 branches:
   only:
@@ -11,7 +13,8 @@ env:
     - secure: "vuLLjmy5cSalvR4ut2Q28YJgVUoSmLQYlhNRyF7zVskO5VFX7RHpfWokrk1SXEQ5hI8bpWOYJOVrcYr05BP0cFvsESlDejaur4rw/gT2nfMkuyWbVhbxH9mFYKeVFWpoC+iezrao9VjMRYySjEJAM4B9mXflN3MQ6ddRaQlBMaI="
 
 script:
-  - echo "ok"
+  - npm install respec serve
+  - node ./tools/validate.js
 
 after_success:
   - CC="mcaceres@mozilla.com,mgiuca@google.com"

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -8,10 +8,6 @@ This change (choose one):
   changes normative sections without changing behavior)
 * [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).
 
-The following tasks have been completed:
-
-* [ ] Confirmed there are no new ReSpec errors/warnings.
-
 Implementation commitment (delete if not making normative changes):
 
 * [ ] Safari (link to issue)

--- a/index.html
+++ b/index.html
@@ -768,7 +768,7 @@
             The <dfn>onappinstalled</dfn> is an <a>event handler IDL
             attribute</a> for the "<dfn>appinstalled</dfn>" event type. The
             interface used for these events is the <a><code>Event</code>
-            interface</a> [[!DOM]]. This event is dispatched as a result of a
+            interface</a> [[!DOMdddd]]. This event is dispatched as a result of a
             <a data-lt="installation succeeded">successful installation</a>
             (see the <a>steps to install the web application</a>).
           </p>

--- a/index.html
+++ b/index.html
@@ -768,7 +768,7 @@
             The <dfn>onappinstalled</dfn> is an <a>event handler IDL
             attribute</a> for the "<dfn>appinstalled</dfn>" event type. The
             interface used for these events is the <a><code>Event</code>
-            interface</a> [[!DOMdddd]]. This event is dispatched as a result of a
+            interface</a> [[!DOM]]. This event is dispatched as a result of a
             <a data-lt="installation succeeded">successful installation</a>
             (see the <a>steps to install the web application</a>).
           </p>

--- a/tools/validate.js
+++ b/tools/validate.js
@@ -5,6 +5,10 @@ const { exec } = require("child_process");
 const handler = require("serve-handler");
 const http = require("http");
 
+/**
+ *
+ * @param {string} cmd A string representing a shell command.
+ */
 function toExecutable(cmd) {
   return {
     get cmd() {
@@ -25,13 +29,22 @@ function toExecutable(cmd) {
   };
 }
 
+/**
+ * Spins up a local HTTP server and checks the spec.
+ * If there are any errors or warnings, the app exits with 1.
+ */
 async function validate() {
-  const conf = { "public": "../" }
   const server = http.createServer((request, response) =>
     handler(request, response)
   );
   server.listen(5000, () => {});
-  const url = `http://localhost:5000/index.html?githubToken=${process.env.AUTHENTICATE}`;
+  const url = `http://localhost:5000/index.html?githubToken=${
+    // This "AUTHENTICATE" is a GitHub token https://github.com/settings/tokens
+    // It needs to be set set on TravisCI itself, via the in the settings
+    // or using Travis' encrypt.
+    process.env.AUTHENTICATE
+  }`;
+  // -e is stop on errors, -w is stop on warnings
   const cmd = `npx respec2html -e -w --timeout 30 --src ${url} --out /dev/null`;
   const exe = toExecutable(cmd);
   try {

--- a/tools/validate.js
+++ b/tools/validate.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/*eslint-env node*/
+"use strict";
+const { exec } = require("child_process");
+const handler = require("serve-handler");
+const http = require("http");
+
+function toExecutable(cmd) {
+  return {
+    get cmd() {
+      return cmd;
+    },
+    run() {
+      return new Promise((resolve, reject) => {
+        const childProcess = exec(cmd, (err, data) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(data);
+        });
+        childProcess.stdout.pipe(process.stdout);
+        childProcess.stderr.pipe(process.stderr);
+      });
+    },
+  };
+}
+
+async function validate() {
+  const conf = { "public": "../" }
+  const server = http.createServer((request, response) =>
+    handler(request, response)
+  );
+  server.listen(5000, () => {});
+  const url = "http://localhost:5000/index.html";
+  const cmd = `npx respec2html --timeout 30 --src ${url} --out /dev/null`;
+  const exe = toExecutable(cmd);
+  try {
+    await exe.run();
+  } catch (err) {
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+validate();

--- a/tools/validate.js
+++ b/tools/validate.js
@@ -31,7 +31,7 @@ async function validate() {
     handler(request, response)
   );
   server.listen(5000, () => {});
-  const url = "http://localhost:5000/index.html";
+  const url = `http://localhost:5000/index.html?githubToken=${process.env.AUTHENTICATE}`;
   const cmd = `npx respec2html --timeout 30 --src ${url} --out /dev/null`;
   const exe = toExecutable(cmd);
   try {

--- a/tools/validate.js
+++ b/tools/validate.js
@@ -32,7 +32,7 @@ async function validate() {
   );
   server.listen(5000, () => {});
   const url = `http://localhost:5000/index.html?githubToken=${process.env.AUTHENTICATE}`;
-  const cmd = `npx respec2html --timeout 30 --src ${url} --out /dev/null`;
+  const cmd = `npx respec2html -e -w --timeout 30 --src ${url} --out /dev/null`;
   const exe = toExecutable(cmd);
   try {
     await exe.run();

--- a/tools/validate.js
+++ b/tools/validate.js
@@ -9,24 +9,25 @@ const http = require("http");
  *
  * @param {string} cmd A string representing a shell command.
  */
-function toExecutable(cmd) {
-  return {
-    get cmd() {
-      return cmd;
-    },
-    run() {
-      return new Promise((resolve, reject) => {
-        const childProcess = exec(cmd, (err, data) => {
-          if (err) {
-            return reject(err);
-          }
-          resolve(data);
-        });
-        childProcess.stdout.pipe(process.stdout);
-        childProcess.stderr.pipe(process.stderr);
+class ShellCommand {
+  constructor(cmd) {
+    this._cmd = cmd;
+  }
+  get cmd() {
+    return this._cmd;
+  }
+  run() {
+    return new Promise((resolve, reject) => {
+      const childProcess = exec(this.cmd, (err, data) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve(data);
       });
-    },
-  };
+      childProcess.stdout.pipe(process.stdout);
+      childProcess.stderr.pipe(process.stderr);
+    });
+  }
 }
 
 /**
@@ -46,9 +47,8 @@ async function validate() {
   }`;
   // -e is stop on errors, -w is stop on warnings
   const cmd = `npx respec2html -e -w --timeout 30 --src ${url} --out /dev/null`;
-  const exe = toExecutable(cmd);
   try {
-    await exe.run();
+    await new ShellCommand(cmd).run();
   } catch (err) {
     process.exit(1);
   }


### PR DESCRIPTION
Part of #733 

This change (choose one):

* [x] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

Check the spec on Travis, meaning we can drop the need to manually check for the spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/739.html" title="Last updated on Nov 13, 2018, 6:02 AM GMT (6abed2f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/739/16c5d13...6abed2f.html" title="Last updated on Nov 13, 2018, 6:02 AM GMT (6abed2f)">Diff</a>