### PR TITLE
Breaking: Ignore any icon with no recognised purpose.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2522,7 +2522,7 @@
           <a>purpose</a>.
         </p>
         <p class="note">
-          For example, an icon with purpose "<a>badge</a>" may be used as a
+          For example, an icon with purpose "<a>badge</a>" could be used as a
           badge or pinned icon that is visually distinct, in color or form,
           from an application's launch icon. The user agent uses the value of
           the <a>purpose</a> member as a hint to determine where and how an
@@ -2557,13 +2557,12 @@
           </dd>
         </dl>
         <p class="note">
-          If an icon contains multiple purposes, it can be used for any of
-          those purposes. If all of the stated purposes are not recognized, the
+          If an icon contains multiple purposes, it could be used for any of
+          those purposes. If none of the stated purposes are recognized, the
           icon is totally ignored. For example, if an icon has purpose
-          <code>"badge fizzbuzz"</code>, then it may be used as a badge, but if
-          an icon has purpose <code>"fizzbuzz"</code>, then it must be ignored.
-          This allows new purposes to be added to the standard in the future
-          without them being interpreted as normal icons by older user agents.
+          <code>"badge fizzbuzz"</code>, then it could be used as a badge, but
+          if an icon has just the purpose <code>"fizzbuzz"</code>, then it will
+          be ignored.
         </p>
         <p>
           The steps for <dfn>processing the <code>purpose</code> member of an

--- a/index.html
+++ b/index.html
@@ -2518,11 +2518,11 @@
           When an <a>ImageResource</a> is used as an <dfn>icon</dfn>, a
           developer can hint that the image is intended to serve some special
           purpose in the context of the host OS (i.e., for better integration).
-          User agents SHOULD NOT use an icon other than for its stated purpose.
+          User agents SHOULD NOT use an icon other than for its stated <a>purpose</a>.
         </p>
         <p class="note">
-          For example, an icon with purpose <code>"badge"</code> may be used as
-          a <a data-lt="badge purpose">badge</a> or "pinned" icon that is
+          For example, an icon with purpose "<a>badge</a>" may be used as
+          a <a data-lt="badge purpose">badge</a> or "<a>pinned</a>" icon that is
           visually distinct, in color or form, from an application's launch
           icon. The user agent uses the value of the <a>purpose</a> member as a
           hint to determine where and how an <a>ImageResource</a> is displayed.

--- a/index.html
+++ b/index.html
@@ -2518,7 +2518,8 @@
           When an <a>ImageResource</a> is used as an <dfn>icon</dfn>, a
           developer can hint that the image is intended to serve some special
           purpose in the context of the host OS (i.e., for better integration).
-          User agents SHOULD NOT use an icon other than for its stated <a>purpose</a>.
+          User agents SHOULD NOT use an icon other than for its stated
+          <a>purpose</a>.
         </p>
         <p class="note">
           For example, an icon with purpose "<a>badge</a>" may be used as

--- a/index.html
+++ b/index.html
@@ -2569,7 +2569,7 @@
           The steps for <dfn>processing the <code>purpose</code> member of an
           image</dfn> are given by the following algorithm. The algorithm takes
           an <a>ImageResource</a> <var>image</var>. This algorithm will return
-          a <a>set</a>.
+          a <a>set</a> or failure.
         </p>
         <ol>
           <li>Let <var>set</var> be an empty <a>set</a>.

--- a/index.html
+++ b/index.html
@@ -2518,14 +2518,16 @@
           When an <a>ImageResource</a> is used as an <dfn>icon</dfn>, a
           developer can hint that the image is intended to serve some special
           purpose in the context of the host OS (i.e., for better integration).
+          User agents SHOULD NOT use an icon other than for its stated purpose.
         </p>
-        <p>
-          For example, as a <a data-lt="badge purpose">badge</a> or "pinned"
-          icon that is visually distinct, in color or form, from an
-          application's launch icon. The user agent uses the value of the
-          <a>purpose</a> member as a hint to determine where and how an
-          <a>ImageResource</a> is displayed. Unless declared otherwise by the
-          developer, a user agent can use an icon for <a>any purpose</a>.
+        <p class="note">
+          For example, an icon with purpose <code>"badge"</code> may be used as
+          a <a data-lt="badge purpose">badge</a> or "pinned" icon that is
+          visually distinct, in color or form, from an application's launch
+          icon. The user agent uses the value of the <a>purpose</a> member as a
+          hint to determine where and how an <a>ImageResource</a> is displayed.
+          Unless declared otherwise by the developer, a user agent can use an
+          icon for <a>any purpose</a>.
         </p>
         <p>
           The <dfn>icon purposes</dfn> are as follows:
@@ -2554,6 +2556,11 @@
             The user agent is free to display the icon in any context.
           </dd>
         </dl>
+        <p class="note">
+          If an icon contains multiple purposes, it can be used for any of
+          those purposes. If all of the stated purposes are not recognized, the
+          icon is totally ignored.
+        </p>
         <p>
           The steps for <dfn>processing the <code>purpose</code> member of an
           image</dfn> are given by the following algorithm. The algorithm takes
@@ -2563,33 +2570,34 @@
         <ol>
           <li>Let <var>set</var> be an empty <a>set</a>.
           </li>
+          <li>If <var>image</var> has no <code>"purpose"</code> member, then
+          <a data-lt="set-append">append</a> <code>"any"</code> to
+          <var>set</var>, and return <var>set</var>.
+          </li>
           <li>Let <var>value</var> be <var>image</var>["purpose"].
           </li>
-          <li>If <a>Type</a>(<var>value</var>) is String:
+          <li>Let <a>list</a> <var>keywords</var> be the result of
+          <a>splitting</a> <var>value</var> on spaces.
+          </li>
+          <li>If <var>keywords</var> is empty, then <a data-lt=
+          "set-append">append</a> <code>"any"</code> to <var>set</var>.
+          </li>
+          <li>Otherwise, <a>for each</a> <var>keyword</var> of
+          <var>keywords</var>:
             <ol>
-              <li>Let <a>list</a> <var>keywords</var> be the result of
-              <a>splitting</a> <var>value</var> on spaces.
+              <li>Set <var>keyword</var> to <var>keyword</var>,
+              <a>lowercased</a>.
               </li>
-              <li>
-                <a>For each</a> <var>keyword</var> of <var>keywords</var>:
-                <ol>
-                  <li>Set <var>keyword</var> to <var>keyword</var>,
-                  <a>lowercased</a>.
-                  </li>
-                  <li>If <var>keyword</var> is not one of the <a>icon
-                  purposes</a>, or <var>set</var> <a>contains</a>
-                  <var>keyword</var>, then <a>issue a developer warning</a> and
-                  <a>continue</a>.
-                  </li>
-                  <li>Otherwise, <a data-lt="set-append">append</a>
-                  <var>keyword</var> to <var>set</var>.
-                  </li>
-                </ol>
+              <li>If <var>keyword</var> is not one of the <a>icon purposes</a>,
+              or <var>set</var> <a>contains</a> <var>keyword</var>, then
+              <a>issue a developer warning</a> and <a>continue</a>.
+              </li>
+              <li>Otherwise, <a data-lt="set-append">append</a>
+              <var>keyword</var> to <var>set</var>.
               </li>
             </ol>
           </li>
-          <li>If <var>set</var> <a>is empty</a>, then <a data-lt="set-append">
-            append</a> <code>"any"</code> to <var>set</var>.
+          <li>If <var>set</var> <a>is empty</a>, then return failure.
           </li>
           <li>Return <var>set</var>.
           </li>
@@ -2931,9 +2939,14 @@
                   <a>processing the <code>sizes</code> member of an image</a>
                   given <var>entry</var> and <var>manifest URL</var>.
                   </li>
-                  <li>Set <var>image</var>["purpose"] to the result of running
+                  <li>Let <var>purpose</var> be the result of running
                   <a>processing the <code>purpose</code> member of an image</a>
                   given <var>entry</var> and <var>manifest URL</var>.
+                  </li>
+                  <li>If <var>purpose</var> is failure, <a data-lt=
+                  "iteration-continue">continue</a>.
+                  </li>
+                  <li>Set <var>image</var>["purpose"] to <var>purpose</var>.
                   </li>
                   <li>
                     <a data-lt="list-append">Append</a> <var>image</var> to

--- a/index.html
+++ b/index.html
@@ -2559,7 +2559,11 @@
         <p class="note">
           If an icon contains multiple purposes, it can be used for any of
           those purposes. If all of the stated purposes are not recognized, the
-          icon is totally ignored.
+          icon is totally ignored. For example, if an icon has purpose
+          <code>"badge fizzbuzz"</code>, then it may be used as a badge, but if
+          an icon has purpose <code>"fizzbuzz"</code>, then it must be ignored.
+          This allows new purposes to be added to the standard in the future
+          without them being interpreted as normal icons by older user agents.
         </p>
         <p>
           The steps for <dfn>processing the <code>purpose</code> member of an

--- a/index.html
+++ b/index.html
@@ -2522,13 +2522,12 @@
           <a>purpose</a>.
         </p>
         <p class="note">
-          For example, an icon with purpose "<a>badge</a>" may be used as
-          a <a data-lt="badge purpose">badge</a> or "<a>pinned</a>" icon that is
-          visually distinct, in color or form, from an application's launch
-          icon. The user agent uses the value of the <a>purpose</a> member as a
-          hint to determine where and how an <a>ImageResource</a> is displayed.
-          Unless declared otherwise by the developer, a user agent can use an
-          icon for <a>any purpose</a>.
+          For example, an icon with purpose "<a>badge</a>" may be used as a
+          badge or pinned icon that is visually distinct, in color or form,
+          from an application's launch icon. The user agent uses the value of
+          the <a>purpose</a> member as a hint to determine where and how an
+          <a>ImageResource</a> is displayed. Unless declared otherwise by the
+          developer, a user agent can use an icon for <a>any purpose</a>.
         </p>
         <p>
           The <dfn>icon purposes</dfn> are as follows:


### PR DESCRIPTION
Closes #728.

This change (choose one):

* [X] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative behavior
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Implementation commitment (delete if not making normative changes):

* [ ] Safari (link to issue)
* [X] Chrome (https://crbug.com/905561)
* [ ] Firefox (link to issue)
* [ ] Edge (public signal)

Commit message:

Breaking: Ignore any icon with no recognised purpose.

Previously, if all of an icon's purposes were unrecognised, it could be
used for any purpose. This causes forwards-compatibility issues, since
if we add a new purpose (such as the recently added 'maskable'), old
user agents will interpret icons with that new purpose as 'any', which
is not intended.

Icons with no stated purpose, or whose purpose is the empty string, are
still treated as 'any'.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/741.html" title="Last updated on Nov 16, 2018, 4:01 AM GMT (586d82b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/741/176d3e2...mgiuca:586d82b.html" title="Last updated on Nov 16, 2018, 4:01 AM GMT (586d82b)">Diff</a>