### PR TITLE
Rewrite dir member.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1657,36 +1657,24 @@
             <dfn>auto</dfn>
           </dt>
           <dd>
-            <a data-lt=
-            "steps to programmatically determine the directionality of a member">
-            programmatically determined</a> from the value of the member.
+            no explicit directionality.
           </dd>
         </dl>
-        <p>
+        <p data-link-for="TextDirectionType">
           When displaying the <a>directionality-capable members</a> to an
-          end-user, the user agent MUST use the <a>base direction</a> to
-          compute directional runs and layout or position text correctly in
-          text containing mixed-direction sequences [[!BIDI]]. When the <a>base
-          direction</a> is "<a data-link-for="TextDirectionType">auto</a>" the
-          user agent MUST run the <a>steps to programmatically determine the
-          directionality of a member</a> - and use the resulting
-          <a>text-direction value</a> to assist in displaying the value of the
-          member.
-        </p>
-        <p>
-          The <dfn>steps to programmatically determine the directionality of a
-          member</dfn> are as follows. The algorithm takes the <var>value</var>
-          of a member.
+          end-user, if the <a>base direction</a> is <a>ltr</a> or <a>rtl</a>:
         </p>
         <ol>
-          <li>Find the first character (in logical order) of the
-          <var>value</var> that is of bidirectional character type L, AL, or R
-          [[!BIDI]].
+          <li data-link-for="TextDirectionType">If the member is being
+          displayed in a paragraph by itself, the user agent MUST override Rule
+          P3 of [[!BIDI]], setting the paragraph embedding level to 0 if the
+          <a>base direction</a> is <a>ltr</a>, or 1 if the <a>base
+          direction</a> is <a>rtl</a>.
           </li>
-          <li>If such a character is found and it is of bidirectional character
-          type AL or R, return <code>"rtl"</code>.
-          </li>
-          <li>Otherwise, return <code>"ltr"</code>.
+          <li data-link-for="TextDirectionType">Otherwise, the user agent MUST
+          behave as if the member is in a left-to-right embedding [[!BIDI]] if
+          the <a>base direction</a> is <a>ltr</a>, or a right-to-left embedding
+          if the <a>base direction</a> is <a>rtl</a>.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -1645,19 +1645,19 @@
             <dfn>ltr</dfn>
           </dt>
           <dd>
-            left-to-right text.
+            Left-to-right text.
           </dd>
           <dt>
             <dfn>rtl</dfn>
           </dt>
           <dd>
-            right-to-left text.
+            Right-to-left text.
           </dd>
           <dt>
             <dfn>auto</dfn>
           </dt>
           <dd>
-            no explicit directionality.
+            No explicit directionality.
           </dd>
         </dl>
         <p data-link-for="TextDirectionType">


### PR DESCRIPTION
Closes #742

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative behavior
* [X] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

`dir`=`auto` no longer explicitly overrides the algorithm in [BIDI]. Also the whole thing more formally uses the BIDI infrastructure.

Note: I think this is actually making a slight behavioural change which we may not be OK with (but assuming it brings it more in line with actual implementations): if the member is embedded within another string (such as "Do you want to install %s?"), the new text lets the BIDI algorithm take the wheel, whereas the old text implies (without formally stating) that it would be embedded LTR or RTL depending on the first strong character. I'll have to think on this more.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/743.html" title="Last updated on Nov 29, 2018, 4:48 AM GMT (103c2dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/743/176d3e2...mgiuca:103c2dd.html" title="Last updated on Nov 29, 2018, 4:48 AM GMT (103c2dd)">Diff</a>