### PR TITLE
Redefine "within scope" using concatenate algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -819,11 +819,13 @@
         returns <code>true</code>:
       </p>
       <ol>
-        <li>Let <var>scopePath</var> be the elements of <var>scopes</var>'s
-        <a data-cite="!URL#concept-url-path">path</a>, separated by U+002F (/).
+        <li>Let <var>scopePath</var> be the <a>concatenation</a> of
+        <var>scopes</var>'s <a data-cite="!URL#concept-url-path">path</a>,
+        using U+002F (/).
         </li>
-        <li>Let <var>targetPath</var> be the elements of <var>target</var>'s
-        <a data-cite="!URL#concept-url-path">path</a>, separated by U+002F (/).
+        <li>Let <var>targetPath</var> be the <a>concatenation</a> of
+        <var>target</var>'s <a data-cite="!URL#concept-url-path">path</a>,
+        using U+002F (/).
         </li>
         <li>If <var>target</var> is <a>same origin</a> as <var>scope</var> and
         <var>targetPath</var> starts with <var>scopePath</var>, return
@@ -4055,6 +4057,10 @@
             <li>
               <dfn data-cite="!INFRA#set-append" data-lt="set-append">append
               (for set)</dfn>
+            </li>
+            <li>
+              <dfn data-cite="!INFRA#string-concatenate" data-lt=
+              "concatenation">concatenate</dfn>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative behavior
* [X] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

Redefine "within scope" using concatenate algorithm.

Previous definition was unclear and ambiguous.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/746.html" title="Last updated on Dec 3, 2018, 6:29 AM GMT (4d12ea2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/746/cfac501...mgiuca:4d12ea2.html" title="Last updated on Dec 3, 2018, 6:29 AM GMT (4d12ea2)">Diff</a>