### PR TITLE
Added CatchTypeError to all fields of WebAppManifest and other places.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1580,24 +1580,25 @@
       </h2>
       <pre class="idl">
           dictionary WebAppManifest {
-             TextDirectionType dir = "auto";
-             DOMString lang;
-             USVString name;
-             USVString short_name;
-             USVString description;
-             sequence&lt;ImageResource&gt; icons;
-             sequence&lt;ImageResource&gt; screenshots;
-             sequence&lt;USVString&gt; categories;
-             DOMString iarc_rating_id;
-             USVString start_url;
-             DisplayModeType display = "browser";
-             OrientationLockType orientation;
-             USVString theme_color;
-             USVString background_color;
-             USVString scope;
-             ServiceWorkerRegistrationObject serviceworker;
-             sequence&lt;ExternalApplicationResource&gt; related_applications;
-             boolean prefer_related_applications = "false";
+             [CatchTypeError] TextDirectionType dir = "auto";
+             [CatchTypeError] DOMString lang;
+             [CatchTypeError] USVString name;
+             [CatchTypeError] USVString short_name;
+             [CatchTypeError] USVString description;
+             [CatchTypeError] sequence&lt;[CatchTypeError] ImageResource&gt; icons;
+             [CatchTypeError] sequence&lt;[CatchTypeError] ImageResource&gt; screenshots;
+             [CatchTypeError] sequence&lt;[CatchTypeError] USVString&gt; categories;
+             [CatchTypeError] DOMString iarc_rating_id;
+             [CatchTypeError] USVString start_url;
+             [CatchTypeError] DisplayModeType display = "browser";
+             [CatchTypeError] OrientationLockType orientation;
+             [CatchTypeError] USVString theme_color;
+             [CatchTypeError] USVString background_color;
+             [CatchTypeError] USVString scope;
+             [CatchTypeError] ServiceWorkerRegistrationObject serviceworker;
+             [CatchTypeError]
+             sequence&lt;[CatchTypeError] ExternalApplicationResource&gt; related_applications;
+             [CatchTypeError] boolean prefer_related_applications = "false";
           };
       </pre>
       <p>


### PR DESCRIPTION
**DO NOT SUBMIT** just yet. Depends upon heycam/webidl#597 so I'm just posting this as a request for comments.

Closes #611.

This change (choose one):

* [X] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

**However**, while this is marked as breaking, I suspect this reverts a previous breakage back to the previous behaviour (members with type errors invalidate just the member, not the whole manifest). I'll have to investigate the old text and other implementations. The goal of this is to *improve* spec compatibility with implementations.

Implementation commitment (delete if not making normative changes):

* [ ] Safari (link to issue)
* [ ] Chrome (link to issue)
* [ ] Firefox (link to issue)
* [ ] Edge (public signal)

Commit message:

This restores the previous behaviour (before we switched to WebIDL)
where individual elements being a type error would not invalidate the
whole manifest.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/750.html" title="Last updated on Dec 10, 2018, 6:24 AM GMT (7999f5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/750/3ea8093...mgiuca:7999f5f.html" title="Last updated on Dec 10, 2018, 6:24 AM GMT (7999f5f)">Diff</a>