### PR TITLE
When converting the JSON to IDL, catch type errors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1475,7 +1475,22 @@
           </li>
           <li>Let <var>manifest</var> be the result of <a data-lt=
           "to idl dictionary value">converting</a> <var>json</var> to a
-          <a>WebAppManifest</a> dictionary.
+          <a>WebAppManifest</a> dictionary, with the following exceptions:
+            <ol>
+              <li>If, during the conversion of any top-level member of the <a>
+                WebAppManifest</a> dictionary, a <a><code>TypeError</code></a>
+                is thrown, catch the exception, <a>issue a developer
+                warning</a>, and set that member to its default value.
+              </li>
+              <li>If, for any top-level member of the <a>WebAppManifest</a>
+              dictionary with a <a data-cite=
+              "!WEBIDL#idl-sequence"><code>sequence</code></a> type, during the
+              conversion of one of the elements of that sequence, a
+              <a><code>TypeError</code></a> is thrown, catch the exception, <a>
+                issue a developer warning</a>, and remove that element from the
+                resulting sequence.
+              </li>
+            </ol>
           </li>
           <li>Set <var>manifest</var>["<a>start_url</a>"] to the result of
           running <a>processing the <code>start_url</code> member</a> given
@@ -4077,6 +4092,11 @@
             <li>
               <a data-cite=
               "!ECMASCRIPT#sec-ecmascript-data-types-and-values"><dfn>Type</dfn>(<var>x</var>)</a>
+            </li>
+            <li>
+              <a data-cite=
+              "!ECMASCRIPT#sec-native-error-types-used-in-this-standard-typeerror">
+              <dfn>TypeError</dfn></a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Closes #611

This change (choose one):

* [x] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Implementation commitment (delete if not making normative changes):

* [ ] Safari (link to issue)
* [ ] Chrome (link to issue)
* [ ] Firefox (link to issue)
* [ ] Edge (public signal)

Commit message:

This makes explicit the behaviour we had previously (before converting to IDL), and that implemented by browsers, of falling back to the default value for individual manifest members with a type error, rather than failing the whole conversion, which would be the normal behaviour of the IDL converter.

While labeled as breaking, this should cause the spec to match implementations more closely, since they should not be failing the whole manifest if a single member is invalid.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/753.html" title="Last updated on Jan 3, 2019, 7:11 AM UTC (b2e30fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/753/3ea8093...mgiuca:b2e30fc.html" title="Last updated on Jan 3, 2019, 7:11 AM UTC (b2e30fc)">Diff</a>