### PR TITLE
Export WebAppManifest dfn as a dictionary

### DIFF
--- a/index.html
+++ b/index.html
@@ -1567,7 +1567,7 @@
     </section>
     <section data-dfn-for="WebAppManifest" data-link-for="WebAppManifest">
       <h2>
-        <dfn>WebAppManifest</dfn> dictionary
+        <dfn data-dfn-type="dictionary" data-dfn-for="">WebAppManifest</dfn> dictionary
       </h2>
       <pre class="idl">
           dictionary WebAppManifest {

--- a/index.html
+++ b/index.html
@@ -1567,7 +1567,7 @@
     </section>
     <section data-dfn-for="WebAppManifest" data-link-for="WebAppManifest">
       <h2>
-        <dfn data-dfn-type="dictionary" data-dfn-for="">WebAppManifest</dfn> dictionary
+        <dfn data-dfn-type="dictionary" data-dfn-for="" id="dom-webappmanifest">WebAppManifest</dfn> dictionary
       </h2>
       <pre class="idl">
           dictionary WebAppManifest {

--- a/index.html
+++ b/index.html
@@ -1947,7 +1947,9 @@
           <code>start_url</code> member
         </h3>
         <p>
-          The <dfn>start_url</dfn> member is a <a>string</a> that represents
+          The <dfn data-dfn-for="webappmanifest" data-dfn-type="dict-member"
+          id="dom-webappmanifest-start_url">start_url</dfn> member is a
+          <a>string</a> that represents
           the <dfn>start URL</dfn> , which is <a>URL</a> that the developer
           would prefer the user agent load when the user launches the web
           application (e.g., when the user clicks on the icon of the web


### PR DESCRIPTION
This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [X] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

Export WebAppManifest dfn as a dictionary.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/manifest/pull/767.html" title="Last updated on Jun 24, 2019, 6:36 PM UTC (8bd740a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/767/3223baf...jyasskin:8bd740a.html" title="Last updated on Jun 24, 2019, 6:36 PM UTC (8bd740a)">Diff</a>