### PR TITLE
fix: purpose member type check + empty string handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -2547,42 +2547,38 @@
           be ignored.
         </p>
         <p>
-          The steps for <dfn>processing the <code>purpose</code> member of an
-          image</dfn> are given by the following algorithm. The algorithm takes
-          an <a>ImageResource</a> <var>image</var>. This algorithm will return
-          a <a>set</a> or failure.
+          The steps for <dfn>processing the `purpose` member of an image</dfn>
+          are given by the following algorithm. The algorithm takes an
+          <a>ImageResource</a> |image:ImageResource|. This algorithm returns a
+          [=set=] or failure.
         </p>
         <ol>
-          <li>If <a>Type</a>(<var>image</var>["purpose"]) it not String, or
-          <var>image</var>["purpose"] consists solely of <a>ascii
-          whitespace</a>, then return the <a>set</a> « "any" ».
+          <li>If [=Type=](|image|["purpose"]) it not String, or
+          |image|["purpose"] consists solely of [=ascii whitespace=], then
+          return the [=set=] « "any" ».
           </li>
-          <li>Let <a>list</a> <var>keywords</var> be the result of <a>split on
-          ASCII whitespace</a> <var>image</var>["purpose"].
+          <li>Let |keywords:list&lt;string&gt;| be the result of [=split on
+          ASCII whitespace=] |image|["purpose"].
           </li>
-          <li>If <var>keywords</var> is empty, then return the <a>set</a> «
-          "any" ».
+          <li>If |keywords| is empty, then return the [=set=] « "any" ».
           </li>
-          <li>Let <var>purposes</var> be the empty <a>set</a>.
+          <li>Let |purposes:set| be the empty [=set=].
           </li>
-          <li>[=set/For each=] <var>keyword</var> of <var>keywords</var>:
+          <li>[=set/For each=] |keyword:string| of |keywords|:
             <ol>
-              <li>Set <var>canonicalKeyword</var> to <a>lowercased</a>
-              <var>keyword</var>.
+              <li>Set |canonicalKeyword| to [=lowercased=] |keyword|.
               </li>
-              <li>If <var>canonicalKeyword</var> is not one of the <a>icon
-              purposes</a>, or <var>purposes</var> <a>contains</a>
-              <var>keyword</var>, then <a>issue a developer warning</a> and <a>
-                continue</a>.
+              <li>If |canonicalKeyword| is not one of the [=icon purposes=], or
+              |purposes| [=contains=] |keyword|, then [=issue a developer
+              warning=] and [=continue=].
               </li>
-              <li>Otherwise, [=set/append=] <var>canonicalKeyword</var> to
-              <var>purposes</var>.
+              <li>Otherwise, [=set/append=] |canonicalKeyword| to |purposes|.
               </li>
             </ol>
           </li>
-          <li>If <var>purposes</var> <a>is empty</a>, then return failure.
+          <li>If |purposes| [=is empty=], then return failure.
           </li>
-          <li>Return <var>purposes</var>.
+          <li>Return |purposes|.
           </li>
         </ol>
         <div class="example">

--- a/index.html
+++ b/index.html
@@ -2553,38 +2553,40 @@
           a <a>set</a> or failure.
         </p>
         <ol>
-          <li>Let <var>set</var> be an empty <a>set</a>.
+          <li>Let <var>purposes</var> be an empty <a>set</a>.
           </li>
-          <li>If <var>image</var> has no <code>"purpose"</code> member, then
-          <a data-lt="set-append">append</a> <code>"any"</code> to
-          <var>set</var>, and return <var>set</var>.
+          <li>If <var>image</var> has no `"purpose"` member, then
+          [=set/append=] `"any"` to <var>purposes</var>, and return
+          <var>purposes</var>.
           </li>
           <li>Let <var>value</var> be <var>image</var>["purpose"].
+          </li>
+          <li>If <a>Type</a>(<var>value</var>) it not String, return failure.
           </li>
           <li>Let <a>list</a> <var>keywords</var> be the result of <a>split on
           ASCII whitespace</a> <var>value</var>.
           </li>
-          <li>If <var>keywords</var> is empty, then <a data-lt=
-          "set-append">append</a> <code>"any"</code> to <var>set</var>.
+          <li>If <var>keywords</var> is empty, then [=set/append=] `"any"` to
+          <var>purposes</var>.
           </li>
-          <li>Otherwise, <a>for each</a> <var>keyword</var> of
+          <li>Otherwise, [=set/for each=] <var>keyword</var> of
           <var>keywords</var>:
             <ol>
               <li>Set <var>keyword</var> to <var>keyword</var>,
               <a>lowercased</a>.
               </li>
               <li>If <var>keyword</var> is not one of the <a>icon purposes</a>,
-              or <var>set</var> <a>contains</a> <var>keyword</var>, then
+              or <var>purposes</var> <a>contains</a> <var>keyword</var>, then
               <a>issue a developer warning</a> and <a>continue</a>.
               </li>
               <li>Otherwise, <a data-lt="set-append">append</a>
-              <var>keyword</var> to <var>set</var>.
+              <var>keyword</var> to <var>purposes</var>.
               </li>
             </ol>
           </li>
-          <li>If <var>set</var> <a>is empty</a>, then return failure.
+          <li>If <var>purposes</var> <a>is empty</a>, then return failure.
           </li>
-          <li>Return <var>set</var>.
+          <li>Return <var>purposes</var>.
           </li>
         </ol>
         <div class="example">

--- a/index.html
+++ b/index.html
@@ -2553,8 +2553,9 @@
           a <a>set</a> or failure.
         </p>
         <ol>
-          <li>If <a>Type</a>(<var>image</var>["purpose"]) it not String, then
-          return the <a>set</a> « "any" ».
+          <li>If <a>Type</a>(<var>image</var>["purpose"]) it not String, or
+          <var>image</var>["purpose"] consists solely of <a>ascii
+          whitespace</a>, then return the <a>set</a> « "any" ».
           </li>
           <li>Let <a>list</a> <var>keywords</var> be the result of <a>split on
           ASCII whitespace</a> <var>image</var>["purpose"].

--- a/index.html
+++ b/index.html
@@ -2553,34 +2553,29 @@
           a <a>set</a> or failure.
         </p>
         <ol>
-          <li>Let <var>purposes</var> be an empty <a>set</a>.
-          </li>
-          <li>If <var>image</var> has no `"purpose"` member, then
-          [=set/append=] `"any"` to <var>purposes</var>, and return
-          <var>purposes</var>.
-          </li>
-          <li>Let <var>value</var> be <var>image</var>["purpose"].
-          </li>
-          <li>If <a>Type</a>(<var>value</var>) it not String, return failure.
+          <li>If <a>Type</a>(<var>image</var>["purpose"]) it not String, then
+          return the <a>set</a> « "any" ».
           </li>
           <li>Let <a>list</a> <var>keywords</var> be the result of <a>split on
-          ASCII whitespace</a> <var>value</var>.
+          ASCII whitespace</a> <var>image</var>["purpose"].
           </li>
-          <li>If <var>keywords</var> is empty, then [=set/append=] `"any"` to
-          <var>purposes</var>.
+          <li>If <var>keywords</var> is empty, then return the <a>set</a> «
+          "any" ».
           </li>
-          <li>Otherwise, [=set/for each=] <var>keyword</var> of
-          <var>keywords</var>:
+          <li>Let <var>purposes</var> be the empty <a>set</a>.
+          </li>
+          <li>[=set/For each=] <var>keyword</var> of <var>keywords</var>:
             <ol>
-              <li>Set <var>keyword</var> to <var>keyword</var>,
-              <a>lowercased</a>.
+              <li>Set <var>canonicalKeyword</var> to <a>lowercased</a>
+              <var>keyword</var>.
               </li>
-              <li>If <var>keyword</var> is not one of the <a>icon purposes</a>,
-              or <var>purposes</var> <a>contains</a> <var>keyword</var>, then
-              <a>issue a developer warning</a> and <a>continue</a>.
+              <li>If <var>canonicalKeyword</var> is not one of the <a>icon
+              purposes</a>, or <var>purposes</var> <a>contains</a>
+              <var>keyword</var>, then <a>issue a developer warning</a> and <a>
+                continue</a>.
               </li>
-              <li>Otherwise, <a data-lt="set-append">append</a>
-              <var>keyword</var> to <var>purposes</var>.
+              <li>Otherwise, [=set/append=] <var>canonicalKeyword</var> to
+              <var>purposes</var>.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
Closes #771 

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [X] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Implementation commitment (delete if not making normative changes):

* [ ] Safari (link to issue)
* [x] Chrome - current behavior as per #771 
* [x] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1559412)
* [ ] Edge (public signal)

Commit message:
Clarifies behavior for purpose member type check + empty string handling (to match Chrome):

 * empty string = treat as "any".
 * type check fails = treat as "any".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/775.html" title="Last updated on Aug 6, 2019, 10:55 AM UTC (61a8937)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/775/c10cbdd...61a8937.html" title="Last updated on Aug 6, 2019, 10:55 AM UTC (61a8937)">Diff</a>