### PR TITLE
fix: omit credentials by default when obtaining

### DIFF
--- a/index.html
+++ b/index.html
@@ -1336,13 +1336,18 @@
           value of the <code>href</code> attribute, relative to <a>the
           element's base URL</a>. If parsing fails, then abort these steps.
           </li>
-          <li>Let <var>request</var> be a new [[FETCH]] <a>request</a>, whose
-          URL is <var>manifest URL</var>, and whose <a>context</a> is
-          "<code>manifest</code>".
+          <li>Let |request:Request| be a new <a>Request</a>.
           </li>
-          <li>If the <var>manifest link</var>'s <code>crossOrigin</code>
-          attribute's value is '<code>use-credentials</code>', then set
-          <var>request</var>'s credentials to '<code>include</code>'.
+          <li>Set |request|'s [=request/URL=] to |manifest URL|.
+          </li>
+          <li>Set |request|'s [=request/initiator=] to "`manifest`".
+          </li>
+          <li>If the |manifest link|'s {{HTMLLinkElement/crossOrigin}}
+          attribute's value is "`use-credentials`", then set |request|'s
+          [=request/credentials mode=] to "`include`". Otherwise, set
+          |request|'s [=request/credentials mode=] to "`omit`".
+          </li>
+          <li>Set |request|'s [=request/mode=] is "`cors`".
           </li>
           <li>Await the result of performing a <a>fetch</a> with
           <var>request</var>, letting <var>response</var> be the result.


### PR DESCRIPTION
Closes #776 

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [X] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Implementation commitment (delete if not making normative changes):

* [ ] [Safari](https://github.com/WebKit/webkit/blob/90e9625cdec06ffd201df5d1c9b5fa03b7c02481/Source/WebCore/loader/ApplicationManifestLoader.cpp#L68)
* [X] Chrome
* [X] Firefox - implemented, link coming soon... 
* [ ] Edge (public signal)

Commit message:
Clarifies that credentials should be omitted by default.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/777.html" title="Last updated on Aug 7, 2019, 6:48 AM UTC (3f032a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/777/9270419...3f032a7.html" title="Last updated on Aug 7, 2019, 6:48 AM UTC (3f032a7)">Diff</a>