### PR TITLE
WebAppManifest itself should be top-level (for="")

### DIFF
--- a/index.html
+++ b/index.html
@@ -1573,7 +1573,7 @@
     </section>
     <section data-dfn-for="WebAppManifest" data-link-for="WebAppManifest">
       <h2>
-        <dfn>WebAppManifest</dfn> dictionary
+        <dfn data-dfn-for="">WebAppManifest</dfn> dictionary
       </h2>
       <pre class="idl">
           dictionary WebAppManifest {


### PR DESCRIPTION
This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [x] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message: WebAppManifest itself should be top-level (for="")


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/manifest/pull/785.html" title="Last updated on Sep 21, 2019, 2:13 AM UTC (9b0df94)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/785/6851b18...jyasskin:9b0df94.html" title="Last updated on Sep 21, 2019, 2:13 AM UTC (9b0df94)">Diff</a>