### PR TITLE
Make BeforeInstallPrompt optional

### DIFF
--- a/index.html
+++ b/index.html
@@ -562,10 +562,14 @@
         </p>
       </section>
     </section>
-    <section>
+    <section class="atrisk">
       <h2>
         Installation Events
       </h2>
+      <p>
+        Installation events and supporting the {{BeforeInstallPrompt}} is
+        OPTIONAL.
+      </p>
       <p>
         DOM events <a>fired</a> by this specification use the <dfn>application
         life-cycle task source</dfn>.


### PR DESCRIPTION
Closes #???

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Implementation commitment (delete if not making normative changes):

* [ ] Safari (link to issue)
* [ ] Chrome (link to issue)
* [ ] Firefox (link to issue)
* [ ] Edge (public signal)

Commit message:

(Fill in. If making normative changes, describe exactly what the behavioral
difference will be.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/797.html" title="Last updated on Sep 19, 2019, 5:39 AM UTC (9577457)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/797/ad4e579...9577457.html" title="Last updated on Sep 19, 2019, 5:39 AM UTC (9577457)">Diff</a>