### PR TITLE
Editorial: Consistently use abort not terminate

### DIFF
--- a/index.html
+++ b/index.html
@@ -1351,7 +1351,7 @@
           The <dfn data-lt="obtaining the manifest|obtaining a manifest">steps
           for obtaining a manifest</dfn> are given by the following algorithm.
           The algorithm, if successful, returns a <a>processed manifest</a> and
-          the <var>manifest URL</var>; otherwise, it terminates prematurely and
+          the <var>manifest URL</var>; otherwise, it aborts prematurely and
           returns nothing. In the case of nothing being returned, the user
           agent MUST ignore the manifest declaration. In running these steps, a
           user agent MUST NOT <a>delay the load event</a>.
@@ -1363,11 +1363,11 @@
           order</a> whose <a><code>rel</code> attribute</a> contains the token
           <code>manifest</code>.
           </li>
-          <li>If <var>origin</var> is an <a>opaque origin</a>, terminate this
-          algorithm.
+          <li>If <var>origin</var> is an <a>opaque origin</a>, then abort these
+          steps.
           </li>
-          <li>If <var>manifest link</var> is <code>null</code>, terminate this
-          algorithm.
+          <li>If <var>manifest link</var> is <code>null</code>, then abort
+          these steps.
           </li>
           <li>If <var>manifest link</var>'s <code>href</code> attribute's value
           is the empty <a>string</a>, then abort these steps.
@@ -1392,8 +1392,8 @@
           <li>Await the result of performing a <a>fetch</a> with
           <var>request</var>, letting <var>response</var> be the result.
           </li>
-          <li>If <var>response</var> is a <a>network error</a>, terminate this
-          algorithm.
+          <li>If <var>response</var> is a <a>network error</a>, then abort
+          these steps.
           </li>
           <li>Let <var>text</var> be <a>UTF-8 decode</a> <var>response</var>'s
           <a data-cite="FETCH#concept-request-body">body</a>.

--- a/index.html
+++ b/index.html
@@ -500,7 +500,7 @@
           <li>If there is already an <a data-lt=
           "present an install prompt">install prompt being presented</a> or if
           the <a>steps to install the web application</a> are currently being
-          executed, terminate this algorithm.
+          executed, then abort this step.
           </li>
           <li>
             <a>Queue a task</a> on the <a>application life-cycle task


### PR DESCRIPTION
Closes [#809](https://github.com/w3c/manifest/issues/809)

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [x] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:
standardise 'terminate' to 'abort'


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/contrepoint/manifest/pull/810.html" title="Last updated on Oct 10, 2019, 2:48 AM UTC (7f45db6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/810/978fc3f...contrepoint:7f45db6.html" title="Last updated on Oct 10, 2019, 2:48 AM UTC (7f45db6)">Diff</a>