### PR TITLE
Fix broken specs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3939,11 +3939,6 @@
               event</dfn></a>
             </li>
             <li>
-              <a data-cite=
-              "HTML#meta-application-name"><dfn>application-name</dfn></a>
-            </li>
-            </li>
-            <li>
               <a data-cite="HTML#attr-link-sizes-any"><dfn>any link
               size</dfn></a>
             </li>
@@ -3958,9 +3953,6 @@
             <li>
               <a data-cite="HTML#valid-mime-type"><dfn>valid MIME
               type</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#same-origin"><dfn>same origin</dfn></a>
             </li>
             <li>
               <a data-cite="HTML#the-element's-base-url"><dfn>the element's

--- a/index.html
+++ b/index.html
@@ -3918,16 +3918,8 @@
               loaded</dfn>
             </li>
             <li>
-              <a data-cite="HTML#allowed-to-navigate"><dfn>allowed to
-              navigate</dfn></a>
-            </li>
-            <li>
               <a data-cite="HTML#external-resource-link"><dfn data-lt=
               "External Resource">external Resource link</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#top-level-browsing-context"><dfn>top-level
-              browsing context</dfn></a>
             </li>
             <li>
               <a data-cite="HTML#same-origin"><dfn>same-origin</dfn></a>
@@ -3940,10 +3932,6 @@
             <li>
               <a data-cite="HTML#navigate"><dfn data-lt=
               "navigated|navigate|navigation">navigate algorithm</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#replacement-enabled"><dfn>replacement
-              enabled</dfn></a>
             </li>
             <li>
               <a data-cite="HTML#the-link-element"><dfn data-lt=
@@ -3960,52 +3948,13 @@
               event</dfn></a>
             </li>
             <li>
-              <a data-cite="HTML#tree-order"><dfn>tree order</dfn></a>
-            </li>
-            <li>
               <a data-cite="HTML#attr-link-rel"><dfn><code>rel</code>
-              attribute</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#concept-link-obtain"><dfn>obtain a
-              resource</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#networking-task-source"><dfn>networking task
-              source</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#queue-a-task"><dfn>queue a task</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#origin"><dfn>origin</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#the-a-element"><dfn data-lt="a"><code>a</code>
-              element</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#the-meta-element"><dfn data-lt=
-              "meta"><code>meta</code> element</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#the-area-element"><dfn data-lt=
-              "area"><code>area</code> element</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#attr-meta-name"><dfn><code>name</code>
               attribute</dfn></a>
             </li>
             <li>
               <a data-cite=
               "HTML#meta-application-name"><dfn>application-name</dfn></a>
             </li>
-            <li>
-              <a data-cite="HTML#the-title-element"><dfn><code>title</code>
-              element</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#rel-icon"><dfn>icon link type</dfn></a>
             </li>
             <li>
               <a data-cite="HTML#ascii-case-insensitive"><dfn>ASCII
@@ -4041,9 +3990,6 @@
             <li>
               <a data-cite="HTML#event-handler-idl-attributes"><dfn data-lt=
               "event handler attributes">Event handler IDL attribute</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#in-parallel"><dfn>in parallel</dfn></a>
             </li>
             <li>
               <a data-cite="HTML#workertype"><dfn>WorkerType</dfn></a>

--- a/index.html
+++ b/index.html
@@ -1263,8 +1263,7 @@
         </h3>
         <p>
           The <code>manifest</code> keyword can be used with a [[HTML]]
-          <a><code>link</code> element</a>. This keyword creates an <a>external
-          resource link</a>.
+          <a><code>link</code> element</a>. This keyword creates an <a data-cite="html">external resource link</a>.
         </p>
         <table class="complex data">
           <thead>
@@ -1294,7 +1293,7 @@
                 <code>manifest</code>
               </td>
               <td>
-                <a>External Resource</a>
+                <a data-cite="html">External Resource Link</a>
               </td>
               <td>
                 not allowed
@@ -3916,10 +3915,6 @@
             <li>
               <dfn data-cite="HTML/parsing.html#completely-loaded">completely
               loaded</dfn>
-            </li>
-            <li>
-              <a data-cite="HTML#external-resource-link"><dfn data-lt=
-              "External Resource">external Resource link</dfn></a>
             </li>
             <li>
               <a data-cite="HTML#same-origin"><dfn>same-origin</dfn></a>

--- a/index.html
+++ b/index.html
@@ -795,7 +795,7 @@
         <p>
           The following extensions to the <code><dfn data-cite=
           "HTML/window-object.html#window">Window</dfn></code> object specify
-          the <a data-cite="html">event handler idl attribute</a> on which events relating to the
+          the <a>event handler idl attribute</a> on which events relating to the
           <a>installation</a> of a web application are <a>fired</a>.
         </p>
         <pre class="idl" data-cite="HTML">
@@ -907,7 +907,7 @@
         unexpected behavior, use a scope ending in a <code>/</code>.
       </div>
       <p>
-        If the <a>application context</a>'s <a data-cite="html">active document</a>'s <a data-cite=
+        If the <a>application context</a>'s <a>active document</a>'s <a data-cite=
         "DOM#concept-document-url">URL</a> is not <a data-lt=
         "within-scope-manifest">within scope</a> of the <a>application
         context</a>'s manifest, the user agent SHOULD show a prominent UI
@@ -1262,7 +1262,7 @@
         </h3>
         <p>
           The <code>manifest</code> keyword can be used with a [[HTML]]
-          <a><code>link</code> element</a>. This keyword creates an <a data-cite="html">external resource link</a>.
+          [^link^] element. This keyword creates an <a>external resource link</a>.
         </p>
         <table class="complex data">
           <thead>
@@ -1292,7 +1292,7 @@
                 <code>manifest</code>
               </td>
               <td>
-                <a data-cite="html">External Resource Link</a>
+                <a>External Resource Link</a>
               </td>
               <td>
                 not allowed

--- a/index.html
+++ b/index.html
@@ -907,14 +907,13 @@
         unexpected behavior, use a scope ending in a <code>/</code>.
       </div>
       <p>
-        If the <a>application context</a>'s <a>active document</a>'s <a data-cite=
-        "DOM#concept-document-url">URL</a> is not <a data-lt=
+        If the <a>application context</a>'s <a>active document</a>'s
+        [=Document/URL=] is not <a data-lt=
         "within-scope-manifest">within scope</a> of the <a>application
         context</a>'s manifest, the user agent SHOULD show a prominent UI
-        element indicating the <a data-cite="DOM#concept-document-url">document
-        URL</a>, or at least its <a>origin</a>, including whether it is served
+        element indicating the [=Document/URL=] or at least its <a>origin</a>, including whether it is served
         over a secure connection. This UI SHOULD differ from any UI used when
-        the <a data-cite="DOM#concept-document-url">document URL</a> is
+        the [=Document/URL=] is
         <a>within scope</a>, in order to make it obvious that the user is
         navigating off scope.
       </p>

--- a/index.html
+++ b/index.html
@@ -3100,7 +3100,7 @@
           The <dfn>type</dfn> member of a
           <a>ServiceWorkerRegistrationObject</a> dictionary is the service
           worker's {{WorkerType}}. The possible values are those of the
-          <a>WorkerType</a> enum defined in [[HTML]].
+          {{WorkerType}} enum defined in [[HTML]].
         </p>
       </section>
       <section data-dfn-for="ServiceWorkerRegistrationObject" data-link-for=
@@ -3984,9 +3984,6 @@
             <li>
               <a data-cite="HTML#event-handler-idl-attributes"><dfn data-lt=
               "event handler attributes">Event handler IDL attribute</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#workertype"><dfn>WorkerType</dfn></a>
             </li>
           </ul>
         </li>

--- a/index.html
+++ b/index.html
@@ -795,8 +795,8 @@
         <p>
           The following extensions to the <code><dfn data-cite=
           "HTML/window-object.html#window">Window</dfn></code> object specify
-          the <a>event handler idl attribute</a> on which events relating to the
-          <a>installation</a> of a web application are <a>fired</a>.
+          the <a>event handler idl attribute</a> on which events relating to
+          the <a>installation</a> of a web application are <a>fired</a>.
         </p>
         <pre class="idl" data-cite="HTML">
           partial interface Window {
@@ -908,14 +908,13 @@
       </div>
       <p>
         If the <a>application context</a>'s <a>active document</a>'s
-        [=Document/URL=] is not <a data-lt=
-        "within-scope-manifest">within scope</a> of the <a>application
-        context</a>'s manifest, the user agent SHOULD show a prominent UI
-        element indicating the [=Document/URL=] or at least its <a>origin</a>, including whether it is served
-        over a secure connection. This UI SHOULD differ from any UI used when
-        the [=Document/URL=] is
-        <a>within scope</a>, in order to make it obvious that the user is
-        navigating off scope.
+        [=Document/URL=] is not <a data-lt="within-scope-manifest">within
+        scope</a> of the <a>application context</a>'s manifest, the user agent
+        SHOULD show a prominent UI element indicating the [=Document/URL=] or
+        at least its <a>origin</a>, including whether it is served over a
+        secure connection. This UI SHOULD differ from any UI used when the
+        [=Document/URL=] is <a>within scope</a>, in order to make it obvious
+        that the user is navigating off scope.
       </p>
       <div class="note">
         <p>
@@ -1261,7 +1260,8 @@
         </h3>
         <p>
           The <code>manifest</code> keyword can be used with a [[HTML]]
-          [^link^] element. This keyword creates an <a>external resource link</a>.
+          [^link^] element. This keyword creates an <a>external resource
+          link</a>.
         </p>
         <table class="complex data">
           <thead>
@@ -1326,8 +1326,8 @@
         </p>
         <p>
           A <a>manifest</a> is obtained and applied regardless of the
-          {{HTMLLinkElement/media}} attribute of the <a><code>link</code> element</a>
-          matches the environment or not.
+          {{HTMLLinkElement/media}} attribute of the <a><code>link</code>
+          element</a> matches the environment or not.
         </p>
       </section>
     </section>
@@ -2884,9 +2884,10 @@
           <li>If <a>Type</a>(<var>value</var>) it not String, return
           <code>undefined</code>.
           </li>
-          <li>If <var>value</var> is not a <a data-cite="mimesniff">valid mime type string</a> or the value
-          of <var>type</var> is not a supported media format, issue a developer
-          warning and return <code>undefined</code>.
+          <li>If <var>value</var> is not a <a data-cite="mimesniff">valid mime
+          type string</a> or the value of <var>type</var> is not a supported
+          media format, issue a developer warning and return
+          <code>undefined</code>.
           </li>
           <li>Return <var>value</var>.
           </li>
@@ -3671,8 +3672,8 @@
         Developers interested in validating <a>manifest</a> documents can find
         an unofficial <a href="http://json.schemastore.org/web-manifest">JSON
         schema for the manifest format</a> at <a href=
-        "http://schemastore.org/json/">schemastore.org</a>. It is licensed under
-        <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache
+        "http://schemastore.org/json/">schemastore.org</a>. It is licensed
+        under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache
         2.0</a>. It is kindly maintained by <a href=
         "https://github.com/madskristensen">Mads Kristensen</a>. If you find
         any issues with the JSON schema, please <a href=

--- a/index.html
+++ b/index.html
@@ -1358,7 +1358,7 @@
           <li>From the {{Document}} of the <a>top-level browsing context</a>,
           let <var>origin</var> be the {{Document}}'s origin, and <var>manifest
           link</var> be the first <a><code>link</code> element</a> in <a>tree
-          order</a> whose <a><code>rel</code> attribute</a> contains the token
+          order</a> whose {{HTMLLinkElement/rel}} contains the token
           <code>manifest</code>.
           </li>
           <li>If <var>origin</var> is an <a>opaque origin</a>, then abort these
@@ -3940,10 +3940,6 @@
             <li>
               <a data-cite="HTML#delay-the-load-event"><dfn>delay the load
               event</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#attr-link-rel"><dfn><code>rel</code>
-              attribute</dfn></a>
             </li>
             <li>
               <a data-cite=

--- a/index.html
+++ b/index.html
@@ -907,8 +907,7 @@
         unexpected behavior, use a scope ending in a <code>/</code>.
       </div>
       <p>
-        If the <a>application context</a>'s <a data-cite=
-        "HTML#active-document">active document</a>'s <a data-cite=
+        If the <a>application context</a>'s <a data-cite="html">active document</a>'s <a data-cite=
         "DOM#concept-document-url">URL</a> is not <a data-lt=
         "within-scope-manifest">within scope</a> of the <a>application
         context</a>'s manifest, the user agent SHOULD show a prominent UI

--- a/index.html
+++ b/index.html
@@ -1357,7 +1357,7 @@
           <li>From the {{Document}} of the <a>top-level browsing context</a>,
           let <var>origin</var> be the {{Document}}'s origin, and <var>manifest
           link</var> be the first <a><code>link</code> element</a> in <a>tree
-          order</a> whose {{HTMLLinkElement/rel}} contains the token
+          order</a> whose {{HTMLLinkElement/rel}} attribute contains the token
           <code>manifest</code>.
           </li>
           <li>If <var>origin</var> is an <a>opaque origin</a>, then abort these

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
         {
           name: "Rob Dolin",
           company: "Microsoft Corporation",
-          companyURL: "https://microsoft.com/",
+          companyURL: "https://www.microsoft.com/en-us/",
         },
       ],
       editors: [
@@ -38,7 +38,7 @@
         {
           name: "Mounir Lamouri",
           company: "Google Inc.",
-          companyURL: "https://google.com/",
+          companyURL: "https://www.google.com/",
           w3cid: 45389,
         },
         {
@@ -50,7 +50,7 @@
         {
           name: "Matt Giuca",
           company: "Google Inc.",
-          companyURL: "https://google.com/",
+          companyURL: "https://www.google.com/",
           w3cid: 91260,
         },
         {
@@ -78,11 +78,11 @@
             },
             {
               value: "Gecko",
-              href: "https://bugzil.la/997779",
+              href: "https://bugzilla.mozilla.org/show_bug.cgi?id=997779",
             },
             {
               value: "WebKit",
-              href: "https://webkit.org/b/158205",
+              href: "https://bugs.webkit.org/show_bug.cgi?id=158205",
             },
           ],
         },
@@ -3697,7 +3697,7 @@
         Developers interested in validating <a>manifest</a> documents can find
         an unofficial <a href="http://json.schemastore.org/web-manifest">JSON
         schema for the manifest format</a> at <a href=
-        "http://schemastore.org/">schemastore.org</a>. It is licensed under
+        "http://schemastore.org/json/">schemastore.org</a>. It is licensed under
         <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache
         2.0</a>. It is kindly maintained by <a href=
         "https://github.com/madskristensen">Mads Kristensen</a>. If you find

--- a/index.html
+++ b/index.html
@@ -3951,10 +3951,6 @@
             </li>
             </li>
             <li>
-              <a data-cite="HTML#ascii-case-insensitive"><dfn>ASCII
-              case-insensitive</dfn></a>
-            </li>
-            <li>
               <a data-cite="HTML#attr-link-sizes-any"><dfn>any link
               size</dfn></a>
             </li>

--- a/index.html
+++ b/index.html
@@ -1327,7 +1327,7 @@
         </p>
         <p>
           A <a>manifest</a> is obtained and applied regardless of the
-          <a>media</a> attribute of the <a><code>link</code> element</a>
+          {{HTMLLinkElement/media}} attribute of the <a><code>link</code> element</a>
           matches the environment or not.
         </p>
       </section>
@@ -3933,9 +3933,6 @@
             </li>
             <li>
               <a data-cite="HTML#linkTypes"><dfn>link type</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#attr-link-media"><dfn>media</dfn></a>
             </li>
             <li>
               <a data-cite="HTML#delay-the-load-event"><dfn>delay the load

--- a/index.html
+++ b/index.html
@@ -795,7 +795,7 @@
         <p>
           The following extensions to the <code><dfn data-cite=
           "HTML/window-object.html#window">Window</dfn></code> object specify
-          the <a>event handler attributes</a> on which events relating to the
+          the <a data-cite="html">event handler idl attribute</a> on which events relating to the
           <a>installation</a> of a web application are <a>fired</a>.
         </p>
         <pre class="idl" data-cite="HTML">
@@ -3969,10 +3969,6 @@
             <li>
               <a data-cite="HTML#queue-a-post-load-task"><dfn>queue a post-load
               task</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#event-handler-idl-attributes"><dfn data-lt=
-              "event handler attributes">Event handler IDL attribute</dfn></a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Fixes some of the issues in [#735](https://github.com/w3c/manifest/issues/735)

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [x] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:
- update 301 links to their final redirect
- remove unused specs
- update spec references using https://respec.org/xref/

@marcoscaceres I've opened `index.html` locally on this branch. There are no errors. There are some specs that I could not find in xref and removing them resulted in errors.  Thus, I have left them in. I've PMed the list to you.

Please let me know what to do next. Thanks!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/contrepoint/manifest/pull/815.html" title="Last updated on Oct 16, 2019, 10:40 AM UTC (59fa6c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/815/c3e18c8...contrepoint:59fa6c2.html" title="Last updated on Oct 16, 2019, 10:40 AM UTC (59fa6c2)">Diff</a>