### PR TITLE
chore: remove some cross referenced terms

### DIFF
--- a/index.html
+++ b/index.html
@@ -2224,7 +2224,7 @@
                   application</a> given <var>app</var>["url"].
                   </li>
                   <li>
-                    <a data-lt="list-append">Append</a> <var>app</var> to
+                    [=list/append=] <var>app</var> to
                     <var>relatedApplications</var>
                   </li>
                 </ol>
@@ -2948,7 +2948,7 @@
               <var>entry</var>["platform"].
               </li>
               <li>
-                <a data-lt="list-append">Append</a> <var>image</var> to
+                [=list/append=] <var>image</var> to
                 <var>imageResources</var>
               </li>
             </ol>
@@ -3898,10 +3898,6 @@
           <ul>
             <li>
               <dfn data-cite="INFRA#list-contain">contains</dfn>
-            </li>
-            <li>
-              <dfn data-cite="INFRA#list-append" data-lt="list-append">append
-              (for list)</dfn>
             </li>
             <li>
               <dfn data-cite="INFRA#set-append" data-lt="set-append">append

--- a/index.html
+++ b/index.html
@@ -699,7 +699,7 @@
                 "DOM#dom-event-istrusted"><code>isTrusted</code></a> attribute
                 is <code>false</code>, reject
                 <var>this</var>.<a>[[\userResponsePromise]]</a> with
-                <a>NotAllowedError</a>, optionally informing the developer that
+                {{"NotAllowedError"}}, optionally informing the developer that
                 untrusted events can't call <code>prompt()</code>.
                 </li>
                 <li>Else if <var>this</var>.<a>[[\didPrompt]]</a> is
@@ -3835,10 +3835,6 @@
         </li>
         <li>[[WEBIDL]] defines the following terms:
           <ul>
-            <li>
-              <a data-cite=
-              "WEBIDL#notallowederror"><dfn>NotAllowedError</dfn></a>
-            </li>
             <li>
               <a data-cite="WEBIDL#es-dictionary"><dfn data-lt=
               "to idl dictionary value">converted to IDL dictionary

--- a/index.html
+++ b/index.html
@@ -2839,7 +2839,7 @@
             [=list/For each=]> <var>keyword</var> of <var>keywords</var>:
             <ol>
               <li>
-                <a data-lt="set-append">Append</a> <var>keyword</var>,
+                [=set/append=] <var>keyword</var>,
                 <a>ascii lowercased</a>, to <var>set</var>.
               </li>
             </ol>
@@ -3898,10 +3898,6 @@
           <ul>
             <li>
               <dfn data-cite="INFRA#list-contain">contains</dfn>
-            </li>
-            <li>
-              <dfn data-cite="INFRA#set-append" data-lt="set-append">append
-              (for set)</dfn>
             </li>
           </ul>
         </li>

--- a/index.html
+++ b/index.html
@@ -2031,7 +2031,7 @@
             <ol>
               <li>
                 <a>Issue a developer warning</a> that the <a>start_url</a>
-                needs to be <a>same-origin</a> as the <code>Document</code> of
+                needs to be <a>same origin</a> as the <code>Document</code> of
                 the <a>top-level browsing context</a>.
               </li>
               <li>Return <var>document URL</var>.
@@ -3893,9 +3893,6 @@
               loaded</dfn>
             </li>
             <li>
-              <a data-cite="HTML#same-origin"><dfn>same-origin</dfn></a>
-            </li>
-            <li>
               <a data-cite=
               "HTML#unordered-set-of-unique-space-separated-tokens"><dfn>unordered
               set of unique space-separated tokens</dfn></a>
@@ -3926,9 +3923,6 @@
             <li>
               <a data-cite="HTML#concept-link-type-sniffing"><dfn>determining
               the type of the resource</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#same-origin"><dfn>same origin</dfn></a>
             </li>
             <li>
               <a data-cite="HTML#the-element's-base-url"><dfn>the element's

--- a/index.html
+++ b/index.html
@@ -2214,7 +2214,7 @@
           as if by the expression [].
           </li>
           <li>
-            <a>For each</a> <var>app</var> of <var>related applications</var>:
+            [=list/For each=] <var>app</var> of <var>related applications</var>:
             <ol>
               <li>if neither <var>app</var>["src"] nor <var>app</var>["url"]
               are <code>undefined</code>:
@@ -2319,7 +2319,7 @@
         </p>
         <ol>
           <li>
-            <a>For each</a> <var>category</var> of <var>categories</var>:
+            [=list/For each=] <var>category</var> of <var>categories</var>:
             <ol>
               <li>
                 [=set/Replace=] <var>category</var> within
@@ -2836,7 +2836,7 @@
           <var>keywords</var> be the result.
           </li>
           <li>
-            <a>For each</a> <var>keyword</var> of <var>keywords</var>:
+            [=list/For each=]> <var>keyword</var> of <var>keywords</var>:
             <ol>
               <li>
                 <a data-lt="set-append">Append</a> <var>keyword</var>,
@@ -2917,7 +2917,7 @@
           by the expression [].
           </li>
           <li>
-            <a>For each</a> <var>entry</var> of <var>entries</var>:
+              [=list/For each=] <var>entry</var> of <var>entries</var>:
           </li>
           <li>If <var>entry</var>["src"] is not <code>undefined</code>:
             <ol>
@@ -3931,9 +3931,6 @@
         </li>
         <li>[[INFRA]] defines the following terms:
           <ul>
-            <li>
-              <dfn data-cite="INFRA#list-iterate">for each</dfn> (for list)
-            </li>
             <li>
               <dfn data-cite="INFRA#iteration-continue">continue</dfn>
             </li>

--- a/index.html
+++ b/index.html
@@ -2610,7 +2610,7 @@
               </li>
               <li>If |canonicalKeyword| is not one of the [=icon purposes=], or
               |purposes| [=contains=] |keyword|, then [=issue a developer
-              warning=] and [=continue=].
+              warning=] and [=iteration/continue=].
               </li>
               <li>Otherwise, [=set/append=] |canonicalKeyword| to |purposes|.
               </li>
@@ -2940,8 +2940,7 @@
               the <code>purpose</code> member of an image</a> given
               <var>entry</var> and <var>manifest URL</var>.
               </li>
-              <li>If <var>purpose</var> is failure, <a data-lt=
-              "iteration-continue">continue</a>.
+              <li>If <var>purpose</var> is failure, [=iteration/continue=].
               </li>
               <li>Set <var>image</var>["purpose"] to <var>purpose</var>.
               </li>
@@ -3931,9 +3930,6 @@
         </li>
         <li>[[INFRA]] defines the following terms:
           <ul>
-            <li>
-              <dfn data-cite="INFRA#iteration-continue">continue</dfn>
-            </li>
             <li>
               <dfn data-cite="INFRA#list-contain">contains</dfn>
             </li>

--- a/index.html
+++ b/index.html
@@ -3854,25 +3854,6 @@
             </li>
           </ul>
         </li>
-        <li>[[FETCH]] defines the following terms:
-          <ul data-sort="">
-            <li>
-              <dfn data-cite="FETCH#concept-fetch">Fetch</dfn>
-            </li>
-            <li>
-              <dfn data-cite="FETCH#concept-response">Response</dfn>
-            </li>
-            <li>
-              <dfn data-cite="FETCH#concept-request">Request</dfn>
-            </li>
-            <li>
-              <dfn data-cite="FETCH#concept-network-error">Network error</dfn>
-            </li>
-            <li>
-              <dfn data-cite="FETCH#concept-request-context">Context</dfn>
-            </li>
-          </ul>
-        </li>
         <li>[[HTML]] defines the following terms:
           <ul>
             <li>

--- a/index.html
+++ b/index.html
@@ -2831,7 +2831,7 @@
           {{HTMLLinkElement/sizes}} attribute and let <a>list</a>
           <var>keywords</var> be the result.
           </li>
-          <li>[=list/For each=]&gt; <var>keyword</var> of <var>keywords</var>:
+          <li>[=list/For each=] <var>keyword</var> of <var>keywords</var>:
             <ol>
               <li>[=set/append=] <var>keyword</var>, <a>ascii lowercased</a>,
               to <var>set</var>.

--- a/index.html
+++ b/index.html
@@ -2616,7 +2616,7 @@
               </li>
             </ol>
           </li>
-          <li>If |purposes| [=is empty=], then return failure.
+          <li>If |purposes| [=list/is empty=], then return failure.
           </li>
           <li>Return |purposes|.
           </li>
@@ -3898,9 +3898,6 @@
           <ul>
             <li>
               <dfn data-cite="INFRA#list-contain">contains</dfn>
-            </li>
-            <li>
-              <dfn data-cite="INFRA#list-is-empty">is empty</dfn>
             </li>
             <li>
               <dfn data-cite="INFRA#list-append" data-lt="list-append">append

--- a/index.html
+++ b/index.html
@@ -1950,7 +1950,7 @@
           The <dfn>orientation</dfn> member is a <a>string</a> that serves as
           the <a>default orientation</a> for all <a>top-level browsing
           contexts</a> of the web application. The possible values are those of
-          the {{orientationlocktype}} enum defined in [[SCREEN-ORIENTATION]].
+          the {{OrientationLockType}} enum defined in [[SCREEN-ORIENTATION]].
         </p>
         <p>
           If the user agent honors the value of the <a>orientation</a> member
@@ -1963,7 +1963,7 @@
         </p>
         <p>
           Although the specification relies on the [[SCREEN-ORIENTATION]]'s
-          {{orientationlocktype}}, it is OPTIONAL for a user agent to implement
+          {{OrientationLockType}}, it is OPTIONAL for a user agent to implement
           the [[SCREEN-ORIENTATION]] API. Supporting the [[SCREEN-ORIENTATION]]
           API is, of course, RECOMMENDED.
         </p>

--- a/index.html
+++ b/index.html
@@ -246,9 +246,8 @@
         <p>
           Example of using a [^link^] element to associate a website with a
           <a>manifest</a>. The example also shows how to use [[HTML]]'s
-          [^link^] and <a data-tl=
-          "meta element">`meta`</a> elements to give the web application a
-          fallback name and set of icons.
+          [^link^] and <a data-tl="meta element">`meta`</a> elements to give
+          the web application a fallback name and set of icons.
         </p>
         <pre class="example html" title="linking to a manifest">
           &lt;!doctype&gt;
@@ -880,9 +879,9 @@
         <var>scopes</var>'s <a data-cite="URL#concept-url-path">path</a>, using
         U+002F (/).
         </li>
-        <li>Let <var>targetPath</var> be the [=string/concatenation=] of
-        <var>target</var>'s <a data-cite="URL#concept-url-path">path</a>, using
-        U+002F (/).
+        <li>Let <var>targetPath</var> be the [=string/concatenation=] of <var>
+          target</var>'s <a data-cite="URL#concept-url-path">path</a>, using
+          U+002F (/).
         </li>
         <li>If <var>target</var> is <a>same origin</a> as <var>scope</var> and
         <var>targetPath</var> starts with <var>scopePath</var>, return
@@ -1310,10 +1309,10 @@
         <p class="note">
           In cases where more than one [^link^] element with a
           <code>manifest</code> link type appears in a {{Document}}, the user
-          agent uses the first [^link^] element in tree order
-          and ignores all subsequent [^link^] elements with a
-          <code>manifest</code> link type (even if the first element was
-          erroneous). See the steps for <a>obtaining a manifest</a>.
+          agent uses the first [^link^] element in tree order and ignores all
+          subsequent [^link^] elements with a <code>manifest</code> link type
+          (even if the first element was erroneous). See the steps for
+          <a>obtaining a manifest</a>.
         </p>
         <p>
           To obtain a manifest, the user agent MUST run the steps for
@@ -1326,7 +1325,8 @@
         </p>
         <p>
           A <a>manifest</a> is obtained and applied regardless of the
-          {{HTMLLinkElement/media}} attribute of the [^link^] element matches the environment or not.
+          {{HTMLLinkElement/media}} attribute of the [^link^] element matches
+          the environment or not.
         </p>
       </section>
     </section>
@@ -1355,8 +1355,8 @@
         <ol>
           <li>From the {{Document}} of the <a>top-level browsing context</a>,
           let <var>origin</var> be the {{Document}}'s origin, and <var>manifest
-          link</var> be the first [^link^] element</a> in <a>tree
-          order</a> whose {{HTMLLinkElement/rel}} attribute contains the token
+          link</var> be the first [^link^] element in <a>tree order</a> whose
+          {{HTMLLinkElement/rel}} attribute contains the token
           <code>manifest</code>.
           </li>
           <li>If <var>origin</var> is an <a>opaque origin</a>, then abort these
@@ -1950,8 +1950,7 @@
           The <dfn>orientation</dfn> member is a <a>string</a> that serves as
           the <a>default orientation</a> for all <a>top-level browsing
           contexts</a> of the web application. The possible values are those of
-          the {{orientationlocktype}} enum defined in
-          [[SCREEN-ORIENTATION]].
+          the {{orientationlocktype}} enum defined in [[SCREEN-ORIENTATION]].
         </p>
         <p>
           If the user agent honors the value of the <a>orientation</a> member
@@ -1964,9 +1963,9 @@
         </p>
         <p>
           Although the specification relies on the [[SCREEN-ORIENTATION]]'s
-          {{orientationlocktype}}, it is OPTIONAL for a user agent to
-          implement the [[SCREEN-ORIENTATION]] API. Supporting the
-          [[SCREEN-ORIENTATION]] API is, of course, RECOMMENDED.
+          {{orientationlocktype}}, it is OPTIONAL for a user agent to implement
+          the [[SCREEN-ORIENTATION]] API. Supporting the [[SCREEN-ORIENTATION]]
+          API is, of course, RECOMMENDED.
         </p>
         <p>
           Certain UI/UX concerns and/or platform conventions will mean that
@@ -2213,8 +2212,8 @@
           <li>Let <var>relatedApplications</var> be a new Array object created
           as if by the expression [].
           </li>
-          <li>
-            [=list/For each=] <var>app</var> of <var>related applications</var>:
+          <li>[=list/For each=] <var>app</var> of <var>related
+          applications</var>:
             <ol>
               <li>if neither <var>app</var>["src"] nor <var>app</var>["url"]
               are <code>undefined</code>:
@@ -2223,9 +2222,8 @@
                   <a>processing the <code>url</code> member of an
                   application</a> given <var>app</var>["url"].
                   </li>
-                  <li>
-                    [=list/append=] <var>app</var> to
-                    <var>relatedApplications</var>
+                  <li>[=list/append=] <var>app</var> to
+                  <var>relatedApplications</var>
                   </li>
                 </ol>
               </li>
@@ -2318,13 +2316,11 @@
           <code>Array&lt;USVString&gt;</code>.
         </p>
         <ol>
-          <li>
-            [=list/For each=] <var>category</var> of <var>categories</var>:
+          <li>[=list/For each=] <var>category</var> of <var>categories</var>:
             <ol>
-              <li>
-                [=set/Replace=] <var>category</var> within
-                <var>categories</var> with <var>category</var>,
-                <a>ascii lowercased</a>.
+              <li>[=set/Replace=] <var>category</var> within
+              <var>categories</var> with <var>category</var>, <a>ascii
+              lowercased</a>.
               </li>
             </ol>
           </li>
@@ -2835,12 +2831,10 @@
           {{HTMLLinkElement/sizes}} attribute and let <a>list</a>
           <var>keywords</var> be the result.
           </li>
-          <li>
-            [=list/For each=]> <var>keyword</var> of <var>keywords</var>:
+          <li>[=list/For each=]&gt; <var>keyword</var> of <var>keywords</var>:
             <ol>
-              <li>
-                [=set/append=] <var>keyword</var>,
-                <a>ascii lowercased</a>, to <var>set</var>.
+              <li>[=set/append=] <var>keyword</var>, <a>ascii lowercased</a>,
+              to <var>set</var>.
               </li>
             </ol>
           </li>
@@ -2916,8 +2910,7 @@
           <li>Let <var>imageResources</var> be a new Array object created as if
           by the expression [].
           </li>
-          <li>
-              [=list/For each=] <var>entry</var> of <var>entries</var>:
+          <li>[=list/For each=] <var>entry</var> of <var>entries</var>:
           </li>
           <li>If <var>entry</var>["src"] is not <code>undefined</code>:
             <ol>
@@ -2947,9 +2940,7 @@
               <li>Set <var>image</var>["platform"] to
               <var>entry</var>["platform"].
               </li>
-              <li>
-                [=list/append=] <var>image</var> to
-                <var>imageResources</var>
+              <li>[=list/append=] <var>image</var> to <var>imageResources</var>
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -3753,9 +3753,6 @@
         <li>[[URL]] defines the following terms:
           <ul>
             <li>
-              <dfn data-cite="URL#concept-url">URL</dfn>
-            </li>
-            <li>
               <dfn data-cite="URL#concept-url-parser" data-lt=
               "parse|parsing|URL parsing">URL parser</dfn>
             </li>

--- a/index.html
+++ b/index.html
@@ -2324,7 +2324,7 @@
               <li>
                 <a data-lt="set-replace">Replace</a> <var>category</var> within
                 <var>categories</var> with <var>category</var>,
-                <a>lowercased</a>.
+                <a>ascii lowercased</a>.
               </li>
             </ol>
           </li>
@@ -2606,7 +2606,7 @@
           </li>
           <li>[=set/For each=] |keyword:string| of |keywords|:
             <ol>
-              <li>Set |canonicalKeyword| to [=lowercased=] |keyword|.
+              <li>Set |canonicalKeyword| to <a>ascii lowercased</a> |keyword|.
               </li>
               <li>If |canonicalKeyword| is not one of the [=icon purposes=], or
               |purposes| [=contains=] |keyword|, then [=issue a developer
@@ -2840,7 +2840,7 @@
             <ol>
               <li>
                 <a data-lt="set-append">Append</a> <var>keyword</var>,
-                <a>lowercased</a>, to <var>set</var>.
+                <a>ascii lowercased</a>, to <var>set</var>.
               </li>
             </ol>
           </li>
@@ -3931,10 +3931,6 @@
         </li>
         <li>[[INFRA]] defines the following terms:
           <ul>
-            <li>
-              <dfn data-cite="INFRA#ascii-lowercase" data-lt="lowercased">ASCII
-              lowercase</dfn>
-            </li>
             <li>
               <dfn data-cite="INFRA#list">list</dfn>
             </li>

--- a/index.html
+++ b/index.html
@@ -3932,12 +3932,6 @@
         <li>[[INFRA]] defines the following terms:
           <ul>
             <li>
-              <dfn data-cite="INFRA#list">list</dfn>
-            </li>
-            <li>
-              <dfn data-cite="INFRA#ordered-set">set</dfn>
-            </li>
-            <li>
               <dfn data-cite="INFRA#set-replace">replace</dfn>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -3787,10 +3787,6 @@
               directive</a>
             </li>
             <li>
-              <a data-cite="CSP3#directive-img-src"><dfn>img-src</dfn>
-              directive</a>
-            </li>
-            <li>
               <a data-cite="CSP3#directive-default-src"><dfn>default-src</dfn>
               directive</a>
             </li>

--- a/index.html
+++ b/index.html
@@ -2322,7 +2322,7 @@
             <a>For each</a> <var>category</var> of <var>categories</var>:
             <ol>
               <li>
-                <a data-lt="set-replace">Replace</a> <var>category</var> within
+                [=set/Replace=] <var>category</var> within
                 <var>categories</var> with <var>category</var>,
                 <a>ascii lowercased</a>.
               </li>
@@ -3931,9 +3931,6 @@
         </li>
         <li>[[INFRA]] defines the following terms:
           <ul>
-            <li>
-              <dfn data-cite="INFRA#set-replace">replace</dfn>
-            </li>
             <li>
               <dfn data-cite="INFRA#list-iterate">for each</dfn> (for list)
             </li>

--- a/index.html
+++ b/index.html
@@ -1950,7 +1950,7 @@
           The <dfn>orientation</dfn> member is a <a>string</a> that serves as
           the <a>default orientation</a> for all <a>top-level browsing
           contexts</a> of the web application. The possible values are those of
-          the <a>OrientationLockType</a> enum defined in
+          the {{orientationlocktype}} enum defined in
           [[SCREEN-ORIENTATION]].
         </p>
         <p>
@@ -1964,7 +1964,7 @@
         </p>
         <p>
           Although the specification relies on the [[SCREEN-ORIENTATION]]'s
-          <a>OrientationLockType</a>, it is OPTIONAL for a user agent to
+          {{orientationlocktype}}, it is OPTIONAL for a user agent to
           implement the [[SCREEN-ORIENTATION]] API. Supporting the
           [[SCREEN-ORIENTATION]] API is, of course, RECOMMENDED.
         </p>

--- a/index.html
+++ b/index.html
@@ -244,9 +244,9 @@
           Using a `link` element to link to a manifest
         </h3>
         <p>
-          Example of using a [=`link` element=] to associate a website with a
+          Example of using a [^link^] element to associate a website with a
           <a>manifest</a>. The example also shows how to use [[HTML]]'s
-          <a data-tl="link element">`link`</a> and <a data-tl=
+          [^link^] and <a data-tl=
           "meta element">`meta`</a> elements to give the web application a
           fallback name and set of icons.
         </p>
@@ -1308,10 +1308,10 @@
           type</a>.
         </p>
         <p class="note">
-          In cases where more than one <a><code>link</code> element</a> with a
+          In cases where more than one [^link^] element with a
           <code>manifest</code> link type appears in a {{Document}}, the user
-          agent uses the first <a><code>link</code> element</a> in tree order
-          and ignores all subsequent <a><code>link</code> element</a> with a
+          agent uses the first [^link^] element in tree order
+          and ignores all subsequent [^link^] elements with a
           <code>manifest</code> link type (even if the first element was
           erroneous). See the steps for <a>obtaining a manifest</a>.
         </p>
@@ -1326,8 +1326,7 @@
         </p>
         <p>
           A <a>manifest</a> is obtained and applied regardless of the
-          {{HTMLLinkElement/media}} attribute of the <a><code>link</code>
-          element</a> matches the environment or not.
+          {{HTMLLinkElement/media}} attribute of the [^link^] element matches the environment or not.
         </p>
       </section>
     </section>
@@ -1356,7 +1355,7 @@
         <ol>
           <li>From the {{Document}} of the <a>top-level browsing context</a>,
           let <var>origin</var> be the {{Document}}'s origin, and <var>manifest
-          link</var> be the first <a><code>link</code> element</a> in <a>tree
+          link</var> be the first [^link^] element</a> in <a>tree
           order</a> whose {{HTMLLinkElement/rel}} attribute contains the token
           <code>manifest</code>.
           </li>
@@ -3900,10 +3899,6 @@
             <li>
               <a data-cite="HTML#navigate"><dfn data-lt=
               "navigated|navigate|navigation">navigate algorithm</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#the-link-element"><dfn data-lt=
-              "link"><code>link</code> element</dfn></a>
             </li>
             <li>
               <a data-cite="HTML#linkTypes"><dfn>link type</dfn></a>

--- a/index.html
+++ b/index.html
@@ -3837,10 +3837,6 @@
           <ul>
             <li>
               <a data-cite=
-              "WEBIDL#invalidstateerror"><dfn>InvalidStateError</dfn></a>
-            </li>
-            <li>
-              <a data-cite=
               "WEBIDL#notallowederror"><dfn>NotAllowedError</dfn></a>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -876,11 +876,11 @@
         returns <code>true</code>:
       </p>
       <ol>
-        <li>Let <var>scopePath</var> be the <a>concatenation</a> of
+        <li>Let <var>scopePath</var> be the [=string/concatenation=] of
         <var>scopes</var>'s <a data-cite="URL#concept-url-path">path</a>, using
         U+002F (/).
         </li>
-        <li>Let <var>targetPath</var> be the <a>concatenation</a> of
+        <li>Let <var>targetPath</var> be the [=string/concatenation=] of
         <var>target</var>'s <a data-cite="URL#concept-url-path">path</a>, using
         U+002F (/).
         </li>
@@ -3953,10 +3953,6 @@
             <li>
               <dfn data-cite="INFRA#set-append" data-lt="set-append">append
               (for set)</dfn>
-            </li>
-            <li>
-              <dfn data-cite="INFRA#string-concatenate" data-lt=
-              "concatenation">concatenate</dfn>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Closes #???

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [x] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:
*  update specs to remove as many cross-referenced terms as possible. reference respec when doing so.

@marcoscaceres
as usual
* I've opened index.html locally on this branch. There are no errors. 
* Ran tidy5 right before pushing this branch
* There are a bunch of cross-referenced terms that I could not remove for various reasons. I've left them in and PMed the list to you. The list is broken down by section.

Please let me know what to do next. Thanks!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/contrepoint/manifest/pull/816.html" title="Last updated on Oct 24, 2019, 2:59 AM UTC (38e2e60)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/816/f069568...contrepoint:38e2e60.html" title="Last updated on Oct 24, 2019, 2:59 AM UTC (38e2e60)">Diff</a>