### PR TITLE
Fixing a typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -2473,7 +2473,7 @@
             <a>top-level browsing context</a> and navigate to
             <samp>https://example.com/play-later</samp>.
             </li>
-            <li>The first shortcut would be displayed with the text
+            <li>The second shortcut would be displayed with the text
             "Subscriptions". When launched, the user agent would instantiate a
             new <a>top-level browsing context</a> and navigate to
             <samp>https://example.com/subscriptions?sort=desc</samp>.


### PR DESCRIPTION
This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [x] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

The text "first" should have been "second" in Example 12.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 4, 2019, 7:32 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fmanifest%2Fbbb49400be7474241d1144dfc85a0e7815c01cde%2Findex.html%3FisPreview%3Dtrue)

```
[33m📡 HTTP Error 520:[39m [36mhttps://rawcdn.githack.com/w3c/manifest/bbb49400be7474241d1144dfc85a0e7815c01cde/index.html[39m
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/manifest%23819.)._
</details>
