### PR TITLE
Editorial: structure loop body with sub-steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -2926,36 +2926,38 @@
           by the expression [].
           </li>
           <li>[=list/For each=] <var>entry</var> of <var>entries</var>:
-          </li>
-          <li>If <var>entry</var>["src"] is not <code>undefined</code>:
             <ol>
-              <li>Let <var>image</var> be a new object created as if by the
-              expression ({}).
-              </li>
-              <li>Set <var>image</var>["src"] to the result of <a>parsing</a>
-              <var>entry</var>["src"] using <var>manifest URL</var> as the base
-              URL.
-              </li>
-              <li>Set <var>image</var>["type"] to the result of running
-              <a>processing the <code>type</code> member of an image</a> given
-              <var>entry</var> and <var>manifest URL</var>.
-              </li>
-              <li>Set <var>image</var>["sizes"] to the result of running
-              <a>processing the <code>sizes</code> member of an image</a> given
-              <var>entry</var> and <var>manifest URL</var>.
-              </li>
-              <li>Let <var>purpose</var> be the result of running <a>processing
-              the <code>purpose</code> member of an image</a> given
-              <var>entry</var> and <var>manifest URL</var>.
-              </li>
-              <li>If <var>purpose</var> is failure, [=iteration/continue=].
-              </li>
-              <li>Set <var>image</var>["purpose"] to <var>purpose</var>.
-              </li>
-              <li>Set <var>image</var>["platform"] to
-              <var>entry</var>["platform"].
-              </li>
-              <li>[=list/append=] <var>image</var> to <var>imageResources</var>
+              <li>If <var>entry</var>["src"] is not <code>undefined</code>:
+                <ol>
+                  <li>Let <var>image</var> be a new object created as if by the
+                  expression ({}).
+                  </li>
+                  <li>Set <var>image</var>["src"] to the result of <a>parsing</a>
+                  <var>entry</var>["src"] using <var>manifest URL</var> as the base
+                  URL.
+                  </li>
+                  <li>Set <var>image</var>["type"] to the result of running
+                  <a>processing the <code>type</code> member of an image</a> given
+                  <var>entry</var> and <var>manifest URL</var>.
+                  </li>
+                  <li>Set <var>image</var>["sizes"] to the result of running
+                  <a>processing the <code>sizes</code> member of an image</a> given
+                  <var>entry</var> and <var>manifest URL</var>.
+                  </li>
+                  <li>Let <var>purpose</var> be the result of running <a>processing
+                  the <code>purpose</code> member of an image</a> given
+                  <var>entry</var> and <var>manifest URL</var>.
+                  </li>
+                  <li>If <var>purpose</var> is failure, [=iteration/continue=].
+                  </li>
+                  <li>Set <var>image</var>["purpose"] to <var>purpose</var>.
+                  </li>
+                  <li>Set <var>image</var>["platform"] to
+                  <var>entry</var>["platform"].
+                  </li>
+                  <li>[=list/append=] <var>image</var> to <var>imageResources</var>
+                  </li>
+                </ol>
               </li>
             </ol>
           </li>


### PR DESCRIPTION
Closes #???

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [x] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/manifest/pull/827.html" title="Last updated on Dec 3, 2019, 6:00 PM UTC (d5846f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/827/8923ba4...bocoup:d5846f4.html" title="Last updated on Dec 3, 2019, 6:00 PM UTC (d5846f4)">Diff</a>