### PR TITLE
Set the manifest request's `destination`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1358,6 +1358,8 @@
           </li>
           <li>Set |request|'s [=request/initiator=] to "`manifest`".
           </li>
+          <li>Set |request|'s [=request/destination=] to "`manifest`".
+          </li>
           <li>If the |manifest link|'s {{HTMLLinkElement/crossOrigin}}
           attribute's value is "`use-credentials`", then set |request|'s
           [=request/credentials mode=] to "`include`". Otherwise, set


### PR DESCRIPTION
This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [x] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

Manifest's fetching algorithm currently defines the request's `initiator` as "manifest",
but neglects to set the `destination`. This patch corrects this minor oversight.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: TypeError: Cannot read property 'owner' of null :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 30, 2020, 5:31 AM UTC)_.

<details>
<summary>More</summary>







_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/manifest%23829.)._
</details>
