### PR TITLE
Rewrite processing shortcuts algorithm to be more precise

### DIFF
--- a/index.html
+++ b/index.html
@@ -1531,7 +1531,7 @@
           </li>
           <li>Set <var>manifest</var>["<a>shortcuts</a>"] to the result of
           running <a>processing the <code>shortcuts</code> member</a> given
-          <var>manifest URL</var>, and <code>"shortcuts"</code>.
+          <var>manifest</var>["<a>shortcuts</a>"] and <var>manifest URL</var>.
           </li>
           <li>
             <a>Extension point</a>: process any proprietary and/or other
@@ -2345,8 +2345,8 @@
           are given by the following algorithm. The algorithm takes a
           <a data-cite=
           "WEBIDL#sequence-type">sequence</a>&lt;<a>ShortcutItem</a>&gt;
-          <var>shortcuts</var> as an argument. This algorithm returns a
-          <a data-cite=
+          <var>shortcuts</var> and a <a>URL</a> <var>manifest URL</var>. This
+          algorithm returns a <a data-cite=
           "WEBIDL#sequence-type">sequence</a>&lt;<a>ShortcutItem</a>&gt;.
         </p>
         <ol>
@@ -2356,13 +2356,22 @@
           <li>For each <var>shortcut</var> (<a>ShortcutItem</a>) in the
           sequence:
             <ol>
+              <li>If <var>shortcut</var>["name"] or <var>shortcut</var>["url"]
+              are undefined, <a>issue a developer warning</a> and
+              <a>continue</a>.
+              </li>
               <li>Set <var>shortcut</var>["icons"] to the result of running <a>
                 processing `ImageResource` members</a> given
                 <var>shortcut</var>["icons"] and <var>manifest URL</var>.
               </li>
               <li>Set <var>shortcut</var>["url"] to the result of
               <a>parsing</a> <var>shortcut</var>["url"] using <var>manifest
-              URL</var> as the base URL.
+              URL</var> as the base URL. If the result is failure, <a>issue a
+              developer warning</a> and <a>continue</a>.
+              </li>
+              <li>If <var>shortcut</var>["url"] is not <a>within scope</a> of
+              <var>manifest URL</var>, <a>issue a developer warning</a> and <a>
+                continue</a>.
               </li>
               <li>
                 <a>Append</a> <var>shortcut</var> to
@@ -3902,6 +3911,9 @@
           <ul>
             <li>
               <dfn data-cite="INFRA#list-contain">contains</dfn>
+            </li>
+            <li>
+              <dfn data-cite="INFRA#iteration-continue">continue</dfn>
             </li>
           </ul>
         </li>

--- a/index.html
+++ b/index.html
@@ -2345,17 +2345,32 @@
           are given by the following algorithm. The algorithm takes a
           <a data-cite=
           "WEBIDL#sequence-type">sequence</a>&lt;<a>ShortcutItem</a>&gt;
-          <var>shortcuts</var> as an argument. This algorithm returns an
+          <var>shortcuts</var> as an argument. This algorithm returns a
           <a data-cite=
-          "WEBIDL#sequence-type">sequence</a>&lt;<a>ShortcutItem</a>&gt;. For
-          each <var>shortcut</var> (<a>ShortcutItem</a>) in the sequence, set
-          <var>shortcut.icons</var> to the result of running <a>processing
-          `ImageResource` members</a> given <var>shortcut.icons</var> and
-          <var>manifest URL</var>. For each <var>shortcut</var>
-          (<a>ShortcutItem</a>) in the sequence, parse
-          <var>shortcut</var>["<a>url</a>"] using <var>manifest URL</var> as
-          the base URL.
+          "WEBIDL#sequence-type">sequence</a>&lt;<a>ShortcutItem</a>&gt;.
         </p>
+        <ol>
+          <li>Let <var>processedShortcuts</var> be a new Array object created
+          as if by the expression [].
+          </li>
+          <li>For each <var>shortcut</var> (<a>ShortcutItem</a>) in the
+          sequence:
+            <ol>
+              <li>Set <var>shortcut</var>["icons"] to the result of running <a>
+                processing `ImageResource` members</a> given
+                <var>shortcut</var>["icons"] and <var>manifest URL</var>.
+              </li>
+              <li>Set <var>shortcut</var>["url"] to the result of parsing <var>
+                shortcut</var>["url"] using <var>manifest URL</var> as the base
+                URL.
+              </li>
+              <li>Append <var>shortcut</var> to <var>processedShortcuts</var>.
+              </li>
+            </ol>
+          </li>
+          <li>Return <var>processedShortcuts</var>.
+          </li>
+        </ol>
         <p>
           A user agent SHOULD expose shortcuts via interactions that are
           consistent with exposure of an application icon's context menu in the

--- a/index.html
+++ b/index.html
@@ -3048,7 +3048,8 @@
         </h3>
         <p>
           The <dfn>url</dfn> member of a <a>ShortcutItem</a> is the <a>URL</a>
-          that opens when the associated shortcut is activated.
+          <a data-lt="within scope of a manifest">within the application's
+          scope</a> that opens when the associated shortcut is activated.
         </p>
       </section>
       <section data-dfn-for="ShortcutItem" data-link-for="ShortcutItem">

--- a/index.html
+++ b/index.html
@@ -2357,8 +2357,8 @@
           sequence:
             <ol>
               <li>If <var>shortcut</var>["name"] or <var>shortcut</var>["url"]
-              are undefined, <a>issue a developer warning</a> and
-              <a>continue</a>.
+              are undefined, or if <var>shortcut</var>["name"] is the empty
+              string, <a>issue a developer warning</a> and <a>continue</a>.
               </li>
               <li>Set <var>shortcut</var>["icons"] to the result of running <a>
                 processing `ImageResource` members</a> given

--- a/index.html
+++ b/index.html
@@ -2360,11 +2360,13 @@
                 processing `ImageResource` members</a> given
                 <var>shortcut</var>["icons"] and <var>manifest URL</var>.
               </li>
-              <li>Set <var>shortcut</var>["url"] to the result of parsing <var>
-                shortcut</var>["url"] using <var>manifest URL</var> as the base
-                URL.
+              <li>Set <var>shortcut</var>["url"] to the result of
+              <a>parsing</a> <var>shortcut</var>["url"] using <var>manifest
+              URL</var> as the base URL.
               </li>
-              <li>Append <var>shortcut</var> to <var>processedShortcuts</var>.
+              <li>
+                <a>Append</a> <var>shortcut</var> to
+                <var>processedShortcuts</var>.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [X] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Implementation commitment (delete if not making normative changes):

To my knowledge, no vendor has implemented this yet, so it is safe to change without getting commitment. This is a very small change to add some new error cases which result in the shortcut items being ignored.

Commit message:

Normative changes:

* shortcuts that meet certain failure conditions are ignored.
  * Checks that name and url are present, URL is valid and within scope of the manifest.

Other changes:

* Clarify that the ShortcutItem url member needs to be within scope.
* Rewrite processing shortcuts algorithm as an ordered list.
* Creates a new array and returns it, rather than discarding the result.
* Explicitly says where developer warnings should be issued.

Closes #831


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/832.html" title="Last updated on Dec 9, 2019, 3:55 AM UTC (36daa47)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/832/a9d989d...mgiuca:36daa47.html" title="Last updated on Dec 9, 2019, 3:55 AM UTC (36daa47)">Diff</a>