### PR TITLE
Chore: Use figures for the mask examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,17 +115,22 @@
         flex-wrap: wrap;
       }
 
-      .icons > div {
+      .icons > figure {
         text-align: left;
+        margin: 0;
         padding: 10px;
         width: 188px;
       }
 
-      .icons > div > img {
+      .icons > figure > img {
         width: 188px;
         height: 188px;
         min-width: 188px;
         min-height: 188px;
+      }
+
+      .icons > figure .icon-title {
+        display: block;
       }
     </style>
   </head>
@@ -2758,81 +2763,95 @@
             Icons with "maskable" purpose
           </h2>
           <div class="icons">
-            <div>
+            <figure>
               <img src="images/icon-plain.svg" alt=
               "An icon over a checkerboard background">
-              <div class="icon-title">
-                Image
-              </div>
-              <div>
-                The base image with transparent background
-              </div>
-            </div>
-            <div>
+              <figcaption>
+                <span class="icon-title">
+                  Image
+                </span>
+                <span>
+                  The base image with transparent background
+                </span>
+              </figcaption>
+            </figure>
+            <figure>
               <img src="images/icon-safe-zone.svg" alt=
               "An icon in a purple circle (40% of the size) over a yellow background">
-              <div class="icon-title">
-                Safe zone
-              </div>
-              <div>
-                Circle with radius 2/5 (40%) of the icon size
-              </div>
-            </div>
+              <figcaption>
+                <span class="icon-title">
+                  Safe zone
+                </span>
+                <span>
+                  Circle with radius 2/5 (40%) of the icon size
+                </span>
+              </figcaption>
+            </figure>
           </div>
           <h2 class="icon-title">
             Mask examples
           </h2>
           <div class="icons">
-            <div>
+            <figure>
               <img src="images/icon-mask-android-roundsquare.svg" alt=
               "An icon inside a rounded yellow square on a purple background">
-              <div class="icon-title">
-                Rounded square
-              </div>
-              <div>
-                Android
-              </div>
-            </div>
-            <div>
+              <figcaption>
+                <span class="icon-title">
+                  Rounded square
+                </span>
+                <span>
+                  Android
+                </span>
+              </figcaption>
+            </figure>
+            <figure>
               <img src="images/icon-mask-android-squircle.svg" alt=
               "An icon inside an extremely rounded yellow square on a purple background">
-              <div class="icon-title">
-                Squircle
-              </div>
-              <div>
-                Android
-              </div>
-            </div>
-            <div>
+              <figcaption>
+                <span class="icon-title">
+                  Squircle
+                </span>
+                <span>
+                  Android
+                </span>
+              </figcaption>
+            </figure>
+            <figure>
               <img src="images/icon-mask-android-circle.svg" alt=
               "An icon inside a rounded yellow circle on a purple background">
-              <div class="icon-title">
-                Circle
-              </div>
-              <div>
-                Android
-              </div>
-            </div>
-            <div>
+              <figcaption>
+                <span class="icon-title">
+                  Circle
+                </span>
+                <span>
+                  Android
+                </span>
+              </figcaption>
+            </figure>
+            <figure>
               <img src="images/icon-mask-ios.svg" alt=
               "An icon inside a somewhat rounded yellow square on a purple background">
-              <div class="icon-title">
-                Rounded square
-              </div>
-              <div>
-                iOS
-              </div>
-            </div>
-            <div>
+              <figcaption>
+                <span class="icon-title">
+                  Rounded square
+                </span>
+                <span>
+                  iOS
+                </span>
+              </figcaption>
+            </figure>
+            <figure>
               <img src="images/icon-mask-windows.svg" alt=
               "An icon on a yellow background">
-              <div class="icon-title">
-                Fullbleed
-              </div>
-              <div>
-                Windows
-              </div>
-            </div>
+              <figcaption>
+                <span class="icon-title">
+                  Fullbleed
+                </span>
+                <span>
+                  Windows
+                </span>
+              </figcaption>
+            </figure>
           </div>
         </section>
       </section>


### PR DESCRIPTION
This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [x] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

Converts the "Mask example" images to use `<figure>`/`<figcaption>` based on comments here: https://github.com/w3c/manifest/pull/833#discussion_r356526848


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 8, 2020, 5:10 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2FNotWoods%2Fmanifest%2Ffd4840aed99bb58122eba29e1c58afb40b6782c4%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/manifest%23852.)._
</details>
