### PR TITLE
Obtain manifests only using the JSON MIME type

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
       }
     </style>
   </head>
-  <body data-cite="ENCODING">
+  <body data-cite="ENCODING MIMESNIFF">
     <section id='abstract'>
       <p>
         This specification defines a JSON-based manifest file that provides
@@ -265,11 +265,12 @@
         <div class="note" title="manifest.webmanifest or manifest.json?">
           The official file extension for the manifest is `.webmanifest`. Some
           web servers recognize this extension and transfer the file using the
-          standardized <a>MIME type for a manifest</a>
-          (`application/manifest+json`). Developers can also choose a different
+          standardized [=web app manifest MIME type=]:
+          [=application/manifest+json=]. Developers can also choose a different
           extension (e.g. `.json`) or none at all (e.g. `/api/GetManifest`),
           but are strongly encouraged to transfer the manifest using the
-          `application/manifest+json` <a data-cite="mimesniff">MIME type</a>.
+          [=application/manifest+json=] [=MIME type=] or, at least, a [=JSON
+          MIME type=].
         </div>
       </section>
     </section>
@@ -1287,9 +1288,9 @@
           </tbody>
         </table>
         <p>
-          The <a>MIME type for a manifest</a> serves as the default
-          <a data-cite="mimesniff">MIME type</a> for resources associated with
-          the "<code>manifest</code>" <a>link type</a>.
+          The [=web app manifest MIME type=] serves as the default [=MIME
+          Type=] for resources associated with the "`manifest`" <a>link
+          type</a>.
         </p>
         <p class="note">
           In cases where more than one [^link^] element with a
@@ -1374,6 +1375,10 @@
           </li>
           <li>Await the result of performing a <a>fetch</a> with
           <var>request</var>, letting <var>response</var> be the result.
+          </li>
+          <li>If [=header list/extract a MIME type=] from |response|'s
+          [=response/header list=] is failure or not a [=JSON MIME Type=], then
+          abort these steps.
           </li>
           <li>If <var>response</var> is a <a>network error</a>, then abort
           these steps.
@@ -2467,11 +2472,10 @@
         semantics of the member that is using the object (e.g., an icon that is
         part of an application menu, etc.). For an image resource, this
         specification provides developers with a means of specifying the
-        dimensions, and <a data-cite="mimesniff">MIME type</a> of an image
-        (i.e., a "responsive image" solution [[RESPIMG-USECASES]]). A user
-        agent can use these values to select an image that is best suited to
-        display on the end-user's device or most closely matches the end-user's
-        preferences.
+        dimensions, and [=MIME Type=] of an image (i.e., a "responsive image"
+        solution [[RESPIMG-USECASES]]). A user agent can use these values to
+        select an image that is best suited to display on the end-user's device
+        or most closely matches the end-user's preferences.
       </p>
       <p>
         User agents may modify the images associated with an
@@ -3301,13 +3305,13 @@
           registration with <a href="https://www.iana.org/">IANA</a>.
         </p>
         <p>
-          The <dfn>MIME type for a manifest</dfn> is
-          <code>application/manifest+json</code>.
+          The <dfn data-export="">web app manifest MIME type</dfn> is
+          <dfn data-export="">`application/manifest+json`</dfn>.
         </p>
         <p>
           If the protocol over which the manifest is transferred supports the
           [[MIME-TYPES]] specification (e.g. HTTP), it is RECOMMENDED that the
-          manifest be labeled with the <a>MIME type for a manifest</a>.
+          manifest be labeled with the [=web app manifest MIME type=].
         </p>
         <dl>
           <dt>

--- a/index.html
+++ b/index.html
@@ -266,10 +266,10 @@
           The official file extension for the manifest is `.webmanifest`. Some
           web servers recognize this extension and transfer the file using the
           standardized [=web app manifest MIME type=]:
-          [=application/manifest+json=]. Developers can also choose a different
+          <a>application/manifest+json</a>. Developers can also choose a different
           extension (e.g. `.json`) or none at all (e.g. `/api/GetManifest`),
           but are strongly encouraged to transfer the manifest using the
-          [=application/manifest+json=] [=MIME type=] or, at least, a [=JSON
+          <a>application/manifest+json</a> [=MIME type=] or, at least, a [=JSON
           MIME type=].
         </div>
       </section>


### PR DESCRIPTION
Closes #821

This change (choose one):

* [X] Adds new normative requirements

Implementation commitment (delete if not making normative changes):

* [ ] Safari (link to issue)
* [ ] Chrome (link to issue)
* [ ] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1626158)
* [ ] Edge (public signal)

Commit message:

When obtaining a manifest, this now checks the mime type is a [JSON mime type](https://mimesniff.spec.whatwg.org/#json-mime-type) (anything that has a `text/json` or `application/json` or +json subtype in "essence"). 

We also now export the mime type from our spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/858.html" title="Last updated on May 25, 2020, 12:08 AM UTC (df0d9d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/858/f704809...df0d9d4.html" title="Last updated on May 25, 2020, 12:08 AM UTC (df0d9d4)">Diff</a>