### PR TITLE
chore: remove implementation status, use MDN data instead

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,30 +63,6 @@
       wg: "Web Applications Working Group",
       wgURI: "https://www.w3.org/2019/webapps/",
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/114929/status",
-      otherLinks: [
-        {
-          key: "Implementation status",
-          data: [
-            {
-              value: "Blink",
-              href: "https://www.chromestatus.com/feature/6488656873259008",
-            },
-            {
-              value: "EdgeHTML",
-              href:
-                "https://developer.microsoft.com/en-us/microsoft-edge/platform/status/webapplicationmanifest/",
-            },
-            {
-              value: "Gecko",
-              href: "https://bugzilla.mozilla.org/show_bug.cgi?id=997779",
-            },
-            {
-              value: "WebKit",
-              href: "https://bugs.webkit.org/show_bug.cgi?id=158205",
-            },
-          ],
-        },
-      ],
       github: "https://github.com/w3c/manifest/",
       caniuse: {
         feature: "web-app-manifest",


### PR DESCRIPTION
This change (choose one):

* [x] Is a "chore" (metadata, formatting, fixing warnings, etc).


the `mdn` option provides more fine grained implementation details. Also, the various boards prevent "robots", which makes auto-publish fail.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/874.html" title="Last updated on May 25, 2020, 9:04 AM UTC (68549d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/874/50d320b...68549d8.html" title="Last updated on May 25, 2020, 9:04 AM UTC (68549d8)">Diff</a>