### PR TITLE
Editorial: ECMA-402 CanonicalizeLanguageTag -> CanonicalizeUnicodeLocaleId

### DIFF
--- a/index.html
+++ b/index.html
@@ -1362,8 +1362,9 @@
           </li>
           <li>If <a>Type</a>(<var>value</var>) is String:
             <ol>
-              <li>If calling <a>IsStructurallyValidLanguageTag</a> with
-              <var>value</var> as the argument returns <code>false</code>,
+              <li>If calling <a data-cite=
+              "ECMA-402#sec-isstructurallyvalidlanguagetag">IsStructurallyValidLanguageTag</a>
+              with <var>value</var> as the argument returns <code>false</code>,
               then:
                 <ol>
                   <li>
@@ -1374,9 +1375,9 @@
                   </li>
                 </ol>
               </li>
-              <li>Otherwise, return the result of calling the
-              <a>CanonicalizeLanguageTag</a> abstract operation, passing <var>
-                V</var> as the argument.
+              <li>Otherwise, return the result of calling the <a data-cite=
+              "ECMA-402#sec-canonicalizeunicodelocaleid">CanonicalizeUnicodeLocaleId</a>
+              abstract operation, passing <var>V</var> as the argument.
               </li>
             </ol>
           </li>
@@ -3443,18 +3444,6 @@
             <li>
               <a data-cite="CSS-SYNTAX-3#parse-component-value"><dfn>parse a
               component value</dfn></a>
-            </li>
-          </ul>
-        </li>
-        <li>[[ECMA-402]] defines the following terms:
-          <ul>
-            <li>
-              <a data-cite=
-              "ECMA-402#sec-isstructurallyvalidlanguagetag"><dfn>IsStructurallyValidLanguageTag</dfn></a>
-            </li>
-            <li>
-              <a data-cite=
-              "ECMA-402#sec-canonicalizelanguagetag"><dfn>CanonicalizeLanguageTag</dfn></a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This change (choose one):

* [x] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)

Commit message:

ECMA-402 renamed the abstract operation `CanonicalizeLanguageTag` to `CanonicalizeUnicodeLocaleId`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/875.html" title="Last updated on May 25, 2020, 11:05 AM UTC (43583b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/875/f1b640a...43583b0.html" title="Last updated on May 25, 2020, 11:05 AM UTC (43583b0)">Diff</a>