### PR TITLE
Clarify off-scope theme color

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,9 +506,10 @@
         [=Document/URL=] is <a>within scope</a>, in order to make it obvious
         that the user is navigating off scope. In addition, the user agent
         SHOULD reset the <a>application context</a>'s <a>default theme
-        color</a> to its default value. The off-scope document may override
-        that color through the inclusion of a valid [[HTML]] <code>meta</code>
-        element whose <code>name</code> attribute is "theme-color".
+        color</a> to a user agent-defined default value. The off-scope document
+        may override that color through the inclusion of a valid [[HTML]]
+        <code>meta</code> element whose <code>name</code> attribute is
+        "theme-color".
       </p>
       <div class="note">
         <p>

--- a/index.html
+++ b/index.html
@@ -504,7 +504,11 @@
         at least its <a>origin</a>, including whether it is served over a
         secure connection. This UI SHOULD differ from any UI used when the
         [=Document/URL=] is <a>within scope</a>, in order to make it obvious
-        that the user is navigating off scope.
+        that the user is navigating off scope. In addition, the user agent
+        SHOULD reset the <a>application context</a>'s <a>default theme
+        color</a> to its default value. The off-scope document may override
+        that color through the inclusion of a valid [[HTML]] <code>meta</code>
+        element whose <code>name</code> attribute is "theme-color".
       </p>
       <div class="note">
         <p>
@@ -1672,11 +1676,11 @@
         <p>
           If the user agent honors the value of the <code>theme_color</code>
           member as the <a>default theme color</a>, then that color serves as
-          the <a>theme color</a> for all browsing contexts to which the
-          manifest is <a>applied</a>. However, a document may override the
-          <a>default theme color</a> through the inclusion of a valid [[HTML]]
-          <code>meta</code> element whose <code>name</code> attribute is
-          "theme-color".
+          the <a>theme color</a> for all browsing contexts <a data-lt=
+          "within-scope-manifest">within scope</a> to which the manifest is
+          <a>applied</a>. However, a document may override the <a>default theme
+          color</a> through the inclusion of a valid [[HTML]] <code>meta</code>
+          element whose <code>name</code> attribute is "theme-color".
         </p>
         <p>
           The steps for <dfn>processing the <code>theme_color</code>


### PR DESCRIPTION
Closes #755

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [x] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Implementation commitment (delete if not making normative changes):

* [ ] Safari (link to issue)
* [ ] Chrome (link to issue)
* [ ] Firefox (link to issue)
* [ ] Edge (public signal)

Commit message:

Currently, the specification does not define which theme color should be applied to an application context when the user navigates off the scope. This change attempts to clarify the behavior.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/christianliebel/manifest/pull/879.html" title="Last updated on May 28, 2020, 12:22 AM UTC (e15b577)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/879/f1b640a...christianliebel:e15b577.html" title="Last updated on May 28, 2020, 12:22 AM UTC (e15b577)">Diff</a>