### PR TITLE
Clarify the definition of "navigation scope", "applied", and off-scope theming

### DIFF
--- a/index.html
+++ b/index.html
@@ -1683,7 +1683,7 @@
           color=] if a document whose URL is [=within scope=] of the
           [=application context=]'s [=manifest=] includes a
           [^meta^] element whose [^meta/name^] attribute is
-          "theme-color". However, the user agent SHOULD NOT override the [=default theme
+        "[^meta/name/theme-color^]". However, the user agent SHOULD NOT override the [=default theme
           color=] via an [^meta^] element whose [^meta/name^] attribute is "theme-color" for
           documents that are not [=within scope=], since the application has no control over
           these documents.

--- a/index.html
+++ b/index.html
@@ -1683,7 +1683,10 @@
           color=] if a document whose URL is [=within scope=] of the
           [=application context=]'s [=manifest=] includes a valid [[HTML]]
           <code>meta</code> element whose <code>name</code> attribute is
-          "theme-color". The user agent SHOULD NOT override the [=default theme
+          "theme-color". However, the user agent SHOULD NOT override the [=default theme
+          color=] via an [^meta^] element whose [^meta/name^] attribute is "theme-color" for
+          documents that are not [=within scope=], since the application has no control over
+          these documents.
           color=] for documents that are not [=within scope=], since the
           application has no control over these documents.
         </p>

--- a/index.html
+++ b/index.html
@@ -1683,7 +1683,7 @@
           color=] if a document whose URL is [=within scope=] of the
           [=application context=]'s [=manifest=] includes a
           [^meta^] element whose [^meta/name^] attribute is
-        "[^meta/name/theme-color^]". However, the user agent SHOULD NOT override the [=default theme
+          "[^meta/name/theme-color^]". However, the user agent SHOULD NOT override the [=default theme
           color=] via an [^meta^] element whose [^meta/name^] attribute is "theme-color" for
           documents that are not [=within scope=], since the application has no control over
           these documents.

--- a/index.html
+++ b/index.html
@@ -1682,7 +1682,7 @@
           [=applied=]. However, the user agent MAY override the [=default theme
           color=] if a document whose URL is [=within scope=] of the
           [=application context=]'s [=manifest=] includes a valid [[HTML]]
-          <code>meta</code> element whose <code>name</code> attribute is
+          [^meta^] element whose [^meta/name^] attribute is
           "theme-color". However, the user agent SHOULD NOT override the [=default theme
           color=] via an [^meta^] element whose [^meta/name^] attribute is "theme-color" for
           documents that are not [=within scope=], since the application has no control over

--- a/index.html
+++ b/index.html
@@ -439,10 +439,9 @@
       </h2>
       <p data-link-for="WebAppManifest">
         A <dfn data-export="">navigation scope</dfn> is a <a>URL</a> that
-        represents the set of URLs to which an <a>application context</a> can
-        be navigated while the manifest is <a>applied</a>. The <a>navigation
-        scope</a> of a manifest <var>manifest</var> is
-        <var>manifest</var>["<a>scope</a>"].
+        represents the set of URLs which are considered to be part of an
+        application. The <a>navigation scope</a> of a manifest
+        <var>manifest</var> is <var>manifest</var>["<a>scope</a>"].
       </p>
       <div class="note" data-link-for="WebAppManifest">
         <p>
@@ -1157,10 +1156,22 @@
           Applying the manifest
         </h3>
         <p>
-          A <a>manifest</a> is <dfn data-lt="apply|applying">applied</dfn> to a
-          <a>top-level browsing context</a>, meaning that the members of the
-          <a>manifest</a> are affecting the presentation or behavior of a
-          browsing context.
+          A <a>manifest</a> can be <dfn data-lt="apply|applying">applied</dfn>
+          to a <a>top-level browsing context</a>, meaning that the members of
+          the <a>manifest</a> are affecting the presentation or behavior of a
+          browsing context. Whenever a <a>top-level browsing context</a> is
+          created, the user agent MAY <a>apply</a> a manifest to it, before
+          [=navigate|navigation=] begins.
+        </p>
+        <p class="note">
+          Whether to [=apply=] a manifest, and which manifest to apply, is at
+          the discretion of the user agent, based on the user's actions. For
+          example, if the user launched an application from the system menu or
+          from a [=launching a shortcut|shortcut=], the user agent might create
+          a new [=top-level browsing context=] with that application's
+          [=manifest=] [=applied=], but it might not do so if the user simply
+          clicked a bookmark to a URL within the application's [=navigation
+          scope=].
         </p>
         <p>
           A <a>top-level browsing context</a> that has a manifest applied to it
@@ -1183,11 +1194,6 @@
             application was <a>installed</a>.
           </p>
         </div>
-        <p>
-          The appropriate time to <a>apply</a> a manifest is when the
-          <a>application context</a> is created and before
-          [=navigate|navigation=] to the <a>start URL</a> begins.
-        </p>
       </section>
       <section id="updating">
         <h3>
@@ -1671,12 +1677,15 @@
         </p>
         <p>
           If the user agent honors the value of the <code>theme_color</code>
-          member as the <a>default theme color</a>, then that color serves as
-          the <a>theme color</a> for all browsing contexts to which the
-          manifest is <a>applied</a>. However, a document may override the
-          <a>default theme color</a> through the inclusion of a valid [[HTML]]
+          member as the [=default theme color=], then that color serves as the
+          [=theme color=] for all browsing contexts to which the manifest is
+          [=applied=]. However, the user agent MAY override the [=default theme
+          color=] if a document whose URL is [=within scope=] of the
+          [=application context=]'s [=manifest=] includes a valid [[HTML]]
           <code>meta</code> element whose <code>name</code> attribute is
-          "theme-color".
+          "theme-color". The user agent SHOULD NOT override the [=default theme
+          color=] for documents that are not [=within scope=], since the
+          application has no control over these documents.
         </p>
         <p>
           The steps for <dfn>processing the <code>theme_color</code>

--- a/index.html
+++ b/index.html
@@ -1160,7 +1160,7 @@
           to a <a>top-level browsing context</a>, meaning that the members of
           the <a>manifest</a> are affecting the presentation or behavior of a
           browsing context. Whenever a <a>top-level browsing context</a> is
-          created, the user agent MAY <a>apply</a> a manifest to it, before
+          created, the user agent MAY <a>apply</a> a manifest to it before
           [=navigate|navigation=] begins.
         </p>
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -1687,7 +1687,6 @@
           color=] via an [^meta^] element whose [^meta/name^] attribute is "theme-color" for
           documents that are not [=within scope=], since the application has no control over
           these documents.
-          application has no control over these documents.
         </p>
         <p>
           The steps for <dfn>processing the <code>theme_color</code>

--- a/index.html
+++ b/index.html
@@ -1681,7 +1681,7 @@
           [=theme color=] for all browsing contexts to which the manifest is
           [=applied=]. However, the user agent MAY override the [=default theme
           color=] if a document whose URL is [=within scope=] of the
-          [=application context=]'s [=manifest=] includes a valid [[HTML]]
+          [=application context=]'s [=manifest=] includes a
           [^meta^] element whose [^meta/name^] attribute is
           "theme-color". However, the user agent SHOULD NOT override the [=default theme
           color=] via an [^meta^] element whose [^meta/name^] attribute is "theme-color" for

--- a/index.html
+++ b/index.html
@@ -1687,7 +1687,6 @@
           color=] via an [^meta^] element whose [^meta/name^] attribute is "theme-color" for
           documents that are not [=within scope=], since the application has no control over
           these documents.
-          color=] for documents that are not [=within scope=], since the
           application has no control over these documents.
         </p>
         <p>


### PR DESCRIPTION
Closes #755.

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [X] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

This further clarifies that a manifest is allowed to apply to URLs that
are not within its scope (that this was not clear was a left-over
mistake from #701), and that a document within scope is allowed to
override the theme color. Adds a new recommendation that an out of scope
document not be allowed to override the theme color.

This introduces new normative recommendations, only insofar as they were
already commonly understood, to my knowledge.

Navigation scope: No longer defined in terms of the URLs that a manifest
is allowed to apply to (since a manifest may apply to any URL). Rather,
it's just a set of URLs; the other normative requirements around
navigation scope define what it means.

Applied: Clarified that it is the user agent's discretion whether or not
to apply a manifest when a top-level browsing context is created, with
examples of when you would and would not apply it (previously, there was
simply no text around when a manifest should be applied).

Theme color: Fixes a "MAY" requirement imposed on the document
(requirements can only be imposed on user agents). Clarifies this
recommendation as only applying to in-scope documents, and adds a
recommendation against applying document theme for out-of-scope
documents.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/880.html" title="Last updated on May 29, 2020, 6:06 AM UTC (d07e2f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/880/f1b640a...mgiuca:d07e2f0.html" title="Last updated on May 29, 2020, 6:06 AM UTC (d07e2f0)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/880.html" title="Last updated on Oct 31, 2024, 10:34 PM UTC (0bcd1d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/880/f1b640a...mgiuca:0bcd1d2.html" title="Last updated on Oct 31, 2024, 10:34 PM UTC (0bcd1d2)">Diff</a>