### PR TITLE
 editorial: shortcut compares wrong scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -460,9 +460,9 @@
         </p>
       </div>
       <p>
-        A [=URL=] |target:URL| is said to be <dfn data-export="">within the
-        navigation scope of</dfn> [=URL=] |scope:URL| if the following
-        algorithm returns `true`:
+        A [=URL=] |target:URL| is said to be <dfn data-dfn-for="URL"
+        data-export="">within scope</dfn> of [=URL=] |scope:URL| if the
+        following algorithm returns `true`:
       </p>
       <ol class="algorithm">
         <li>If |target| and |scope| are not [=same origin=], return `false`.
@@ -479,10 +479,10 @@
         </li>
       </ol>
       <p>
-        A [=URL=] |target:URL| is said to be <dfn data-export="" data-local-lt=
-        "within manifest scope">within the navigation scope of a web
+        A [=URL=] |target:URL| is said to be <dfn data-export="" data-dfn-for=
+        "manifest" data-lt="within scope">within the navigation scope of a web
         manifest</dfn> {{WebAppManifest}} |manifest:WebAppManifest| if [=URL=]
-        |target:URL| is [=within the navigation scope of=] the |manifest|'s
+        |target:URL| is [=manifest/within scope=] of the |manifest|'s
         {{WebAppManifest/scope}} member (once resolved).
       </p>
       <div class="note" title="Scope is a simple string match">
@@ -496,11 +496,11 @@
       </div>
       <p>
         If the <a>application context</a>'s <a>active document</a>'s
-        [=Document/URL=] is not [=within manifest scope=] of the <a>application
+        [=Document/URL=] is not [=manifest/within scope=] of the <a>application
         context</a>'s manifest, the user agent SHOULD show a prominent UI
         element indicating the [=Document/URL=] or at least its <a>origin</a>,
         including whether it is served over a secure connection. This UI SHOULD
-        differ from any UI used when the [=Document/URL=] is [=within manifest
+        differ from any UI used when the [=Document/URL=] is [=manifest/within
         scope=], in order to make it obvious that the user is navigating off
         scope.
       </p>
@@ -536,7 +536,7 @@
           Deep links
         </h3>
         <p>
-          A <dfn>deep link</dfn> is a URL that is [=within manifest scope=] of
+          A <dfn>deep link</dfn> is a URL that is [=manifest/within scope=] of
           an <a>installed web application</a>'s manifest.
         </p>
         <p>
@@ -1427,12 +1427,12 @@
               </li>
             </ul>
           </li>
-          <li>If <var>start URL</var> is not [=within the navigation scope of=]
-          |scope URL|:
+          <li>If <var>start URL</var> is not [=URL/within scope=] of |scope
+          URL|:
             <ol>
               <li>
                 <a>Issue a developer warning</a> that the start URL is not
-                [=within the navigation scope of=] the scope URL.
+                [=URL/within scope=] of the |scope URL|.
               </li>
               <li>Return <var>default</var>.
               </li>
@@ -1978,9 +1978,9 @@
               URL</var> as the base URL. If the result is failure, <a>issue a
               developer warning</a> and [=iteration/continue=].
               </li>
-              <li>If <var>shortcut</var>["url"] is not [=within the navigation
-              scope of=] <var>scope URL</var>, <a>issue a developer warning</a>
-              and [=iteration/continue=].
+              <li>If <var>shortcut</var>["url"] is not [=URL/within scope=]
+              <var>scope URL</var>, <a>issue a developer warning</a> and
+              [=iteration/continue=].
               </li>
               <li>
                 <a>Append</a> <var>shortcut</var> to
@@ -2643,7 +2643,7 @@
         <p>
           The <dfn>url</dfn> member of a <a>ShortcutItem</a> is the <a>URL</a>
           that opens when the associated shortcut is activated. When resolved,
-          the {{ShortcutItem/url}} must be [=within manifest scope=], otherwise
+          the {{ShortcutItem/url}} must be [=URL/within scope=] of scope URL,
           it gets ignored.
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -460,31 +460,30 @@
         </p>
       </div>
       <p>
-        A <a>URL</a> <var>target</var> is said to be <dfn>within scope</dfn> of
-        <a>navigation scope</a> <var>scope</var> if the following algorithm
-        returns <code>true</code>:
+        A [=URL=] |target:URL| is said to be <dfn data-export="">within the
+        navigation scope of</dfn> [=URL=] |scope:URL| if the following
+        algorithm returns `true`:
       </p>
-      <ol>
-        <li>Let <var>scopePath</var> be the [=string/concatenation=] of
-        <var>scopes</var>'s <a data-cite="URL#concept-url-path">path</a>, using
-        U+002F (/).
+      <ol class="algorithm">
+        <li>If |target| and |scope| are not [=same origin=], return `false`.
         </li>
-        <li>Let <var>targetPath</var> be the [=string/concatenation=] of <var>
-          target</var>'s <a data-cite="URL#concept-url-path">path</a>, using
-          U+002F (/).
+        <li>Let |scopePath:string| be the [=string/concatenation=] of
+        |scopes|'s [=URL/path=] and U+002F (/).
         </li>
-        <li>If <var>target</var> is <a>same origin</a> as <var>scope</var> and
-        <var>targetPath</var> starts with <var>scopePath</var>, return
-        <code>true</code>.
+        <li>Let |targetPath:string| be the [=string/concatenation=] of
+        |target|'s [=URL/path=] and U+002F (/).
         </li>
-        <li>Otherwise, return <code>false</code>.
+        <li>If |targetPath| starts with |scopePath:string|, return `true`.
+        </li>
+        <li>Otherwise, return `false`.
         </li>
       </ol>
       <p>
-        A <a>URL</a> <var>target</var> is said to be <dfn data-lt=
-        "within-scope-manifest">within scope of a manifest</dfn>
-        <var>manifest</var> if <var>target</var> is <a>within scope</a> of the
-        navigation scope of <var>manifest</var>.
+        A [=URL=] |target:URL| is said to be <dfn data-export="" data-local-lt=
+        "within manifest scope">within the navigation scope of a web
+        manifest</dfn> {{WebAppManifest}} |manifest:WebAppManifest| if [=URL=]
+        |target:URL| is [=within the navigation scope of=] the |manifest|'s
+        {{WebAppManifest/scope}} member (once resolved).
       </p>
       <div class="note" title="Scope is a simple string match">
         The URL string matching in this algorithm is prefix-based rather than
@@ -497,13 +496,13 @@
       </div>
       <p>
         If the <a>application context</a>'s <a>active document</a>'s
-        [=Document/URL=] is not <a data-lt="within-scope-manifest">within
-        scope</a> of the <a>application context</a>'s manifest, the user agent
-        SHOULD show a prominent UI element indicating the [=Document/URL=] or
-        at least its <a>origin</a>, including whether it is served over a
-        secure connection. This UI SHOULD differ from any UI used when the
-        [=Document/URL=] is <a>within scope</a>, in order to make it obvious
-        that the user is navigating off scope.
+        [=Document/URL=] is not [=within manifest scope=] of the <a>application
+        context</a>'s manifest, the user agent SHOULD show a prominent UI
+        element indicating the [=Document/URL=] or at least its <a>origin</a>,
+        including whether it is served over a secure connection. This UI SHOULD
+        differ from any UI used when the [=Document/URL=] is [=within manifest
+        scope=], in order to make it obvious that the user is navigating off
+        scope.
       </p>
       <div class="note">
         <p>
@@ -537,9 +536,8 @@
           Deep links
         </h3>
         <p>
-          A <dfn>deep link</dfn> is a URL that is <a data-lt=
-          "within-scope-manifest">within scope</a> of an <a>installed web
-          application</a>'s manifest.
+          A <dfn>deep link</dfn> is a URL that is [=within manifest scope=] of
+          an <a>installed web application</a>'s manifest.
         </p>
         <p>
           An <a>application context</a> can be instantiated through a <a>deep
@@ -1428,11 +1426,12 @@
               </li>
             </ul>
           </li>
-          <li>If <var>start URL</var> is not <a>within scope</a> of scope URL:
+          <li>If <var>start URL</var> is not [=within the navigation scope of=]
+          |scope URL|:
             <ol>
               <li>
                 <a>Issue a developer warning</a> that the start URL is not
-                <a>within scope</a> of the scope URL.
+                [=within the navigation scope of=] the scope URL.
               </li>
               <li>Return <var>default</var>.
               </li>

--- a/index.html
+++ b/index.html
@@ -2644,7 +2644,7 @@
           The <dfn>url</dfn> member of a <a>ShortcutItem</a> is the <a>URL</a>
           that opens when the associated shortcut is activated. When resolved,
           the {{ShortcutItem/url}} must be [=URL/within scope=] of scope URL,
-          it gets ignored.
+          otherwise the shortcut gets ignored.
         </p>
       </section>
       <section data-dfn-for="ShortcutItem" data-link-for="ShortcutItem">

--- a/index.html
+++ b/index.html
@@ -1138,8 +1138,9 @@
           member</a> given <var>manifest</var>["<a>related_applications</a>"].
           </li>
           <li>Set <var>manifest</var>["<a>shortcuts</a>"] to the result of
-          running <a>processing the <code>shortcuts</code> member</a> given
-          <var>manifest</var>["<a>shortcuts</a>"] and <var>manifest URL</var>.
+          running <a>processing the `shortcuts` member</a> given
+          <var>manifest</var>["<a>shortcuts</a>"], <var>manifest URL</var>, and
+          <var>scope URL</var>.
           </li>
           <li>
             <a>Extension point</a>: process any proprietary and/or other
@@ -1950,11 +1951,11 @@
           the most critical shortcuts appearing first in the array.
         </p>
         <p>
-          The steps for <dfn>processing the <code>shortcuts</code> member</dfn>
-          are given by the following algorithm. The algorithm takes a
+          The steps for <dfn>processing the `shortcuts` member</dfn> are given
+          by the following algorithm. The algorithm takes a
           <a>sequence</a>&lt;<a>ShortcutItem</a>&gt; <var>shortcuts</var> and a
-          <a>URL</a> <var>manifest URL</var>. This algorithm returns a
-          <a>sequence</a>&lt;<a>ShortcutItem</a>&gt;.
+          <a>URL</a> |manifest URL:URL|, and [=URL=] <var>scope URL</var>. This
+          algorithm returns a <a>sequence</a>&lt;<a>ShortcutItem</a>&gt;.
         </p>
         <ol>
           <li>Let <var>processedShortcuts</var> be a new Array object created
@@ -1977,9 +1978,9 @@
               URL</var> as the base URL. If the result is failure, <a>issue a
               developer warning</a> and [=iteration/continue=].
               </li>
-              <li>If <var>shortcut</var>["url"] is not <a>within scope</a> of
-              <var>manifest URL</var>, <a>issue a developer warning</a> and
-              [=iteration/continue=].
+              <li>If <var>shortcut</var>["url"] is not [=within the navigation
+              scope of=] <var>scope URL</var>, <a>issue a developer warning</a>
+              and [=iteration/continue=].
               </li>
               <li>
                 <a>Append</a> <var>shortcut</var> to
@@ -2641,8 +2642,9 @@
         </h3>
         <p>
           The <dfn>url</dfn> member of a <a>ShortcutItem</a> is the <a>URL</a>
-          <a data-lt="within scope of a manifest">within the application's
-          scope</a> that opens when the associated shortcut is activated.
+          that opens when the associated shortcut is activated. When resolved,
+          the {{ShortcutItem/url}} must be [=within manifest scope=], otherwise
+          it gets ignored.
         </p>
       </section>
       <section data-dfn-for="ShortcutItem" data-link-for="ShortcutItem">


### PR DESCRIPTION
Closes #885

Depends on #882 ... 

I'm going to say this is editorial, as it was clearly not what was was intended... 

This change (choose one):

* [X] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Implementation commitment (delete if not making normative changes):

* [ ] Safari (link to issue)
* [ ] Chrome (link to issue)
* [ ] Firefox (link to issue)
* [ ] Edge (public signal)

Commit message:

Fixes shortcut being compared to incorrect scope.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/886.html" title="Last updated on May 29, 2020, 7:29 AM UTC (39ca0c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/886/9fbabf6...39ca0c8.html" title="Last updated on May 29, 2020, 7:29 AM UTC (39ca0c8)">Diff</a>