### PR TITLE
chore: remove some bad links

### DIFF
--- a/index.html
+++ b/index.html
@@ -960,7 +960,7 @@
           </li>
           <li>Let <var>manifest URL</var> be the result of [=URL
           Parser|parsing=] the value of the <code>href</code> attribute,
-          relative to <a>the element's base URL</a>. If parsing fails, then
+          relative to the [=document base URL=]. If parsing fails, then
           abort these steps.
           </li>
           <li>Let |request:Request| be a new <a>Request</a>.
@@ -3435,10 +3435,6 @@
             <li>
               <a data-cite="HTML#valid-non-negative-integer"><dfn>valid
               non-negative integer</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#the-element's-base-url"><dfn>the element's
-              base URL</dfn></a>.
             </li>
           </ul>
         </li>

--- a/index.html
+++ b/index.html
@@ -2495,8 +2495,7 @@
         </p>
         <p>
           There is no default MIME type for image resources. However, for the
-          purposes of <a>determining the type of the resource</a>, user agents
-          must expect the resource to be an image.
+          user agents MUST use the [=rules for sniffing images specifically=].
         </p>
         <p>
           The steps for <dfn>processing the <code>type</code> member of an
@@ -3436,10 +3435,6 @@
             <li>
               <a data-cite="HTML#valid-non-negative-integer"><dfn>valid
               non-negative integer</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#concept-link-type-sniffing"><dfn>determining
-              the type of the resource</dfn></a>
             </li>
             <li>
               <a data-cite="HTML#the-element's-base-url"><dfn>the element's

--- a/index.html
+++ b/index.html
@@ -894,7 +894,7 @@
         <p>
           The <a>MIME type for a manifest</a> serves as the default
           <a data-cite="mimesniff">MIME type</a> for resources associated with
-          the "<code>manifest</code>" <a>link type</a>.
+          the "<code>manifest</code>" link type.
         </p>
         <p class="note">
           In cases where more than one [^link^] element with a
@@ -3428,9 +3428,6 @@
               <a data-cite=
               "HTML#unordered-set-of-unique-space-separated-tokens"><dfn>unordered
               set of unique space-separated tokens</dfn></a>
-            </li>
-            <li>
-              <a data-cite="HTML#linkTypes"><dfn>link type</dfn></a>
             </li>
             <li>
               <a data-cite="HTML#delay-the-load-event"><dfn>delay the load


### PR DESCRIPTION
This change (choose one):

* [X] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

Drop link "link type", as we don't need it anymore... 
Use "rules for sniffing images specifically" for now, as that also matches image resource spec.
Replace element's base URL to document base URL.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/889.html" title="Last updated on Jun 1, 2020, 9:08 AM UTC (5295857)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/889/9fbabf6...5295857.html" title="Last updated on Jun 1, 2020, 9:08 AM UTC (5295857)">Diff</a>