### PR TITLE
editorial: rename+export 'application manifest MIME type'

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@
         <div class="note" title="manifest.webmanifest or manifest.json?">
           The official file extension for the manifest is `.webmanifest`. Some
           web servers recognize this extension and transfer the file using the
-          standardized <a>MIME type for a manifest</a>
+          standardized <a>application manifest MIME type</a>
           (`application/manifest+json`). Developers can also choose a different
           extension (e.g. `.json`) or none at all (e.g. `/api/GetManifest`),
           but are strongly encouraged to transfer the manifest using the
@@ -904,7 +904,7 @@
           </tbody>
         </table>
         <p>
-          The <a>MIME type for a manifest</a> serves as the default
+          The <a>application manifest MIME type</a> serves as the default
           <a data-cite="mimesniff">MIME type</a> for resources associated with
           the "<code>manifest</code>" link type.
         </p>
@@ -2914,13 +2914,13 @@
           registration with <a href="https://www.iana.org/">IANA</a>.
         </p>
         <p>
-          The <dfn>MIME type for a manifest</dfn> is
-          <code>application/manifest+json</code>.
+          The <dfn data-export="">application manifest MIME type</dfn> is
+          <dfn data-export="">`application/manifest+json`</dfn>.
         </p>
         <p>
           If the protocol over which the manifest is transferred supports the
           [[MIME-TYPES]] specification (e.g. HTTP), it is RECOMMENDED that the
-          manifest be labeled with the <a>MIME type for a manifest</a>.
+          manifest be labeled with the [=application manifest MIME type=].
         </p>
         <dl>
           <dt>


### PR DESCRIPTION
This change (choose one):

* [x] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)

Commit message:

s/MIME type for a manifest/application manifest MIME type, so it matches the name of other types exported from other specs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/893.html" title="Last updated on Jun 2, 2020, 8:00 AM UTC (a3c8468)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/893/2746acc...a3c8468.html" title="Last updated on Jun 2, 2020, 8:00 AM UTC (a3c8468)">Diff</a>