### PR TITLE
fix: shortcuts compares wrong scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -1146,9 +1146,8 @@
           result of running <a>processing the <code>related_applications</code>
           member</a> given <var>manifest</var>["<a>related_applications</a>"].
           </li>
-          <li>Set <var>manifest</var>["<a>shortcuts</a>"] to the result of
-          running <a>processing the <code>shortcuts</code> member</a> given
-          <var>manifest</var>["<a>shortcuts</a>"] and <var>manifest URL</var>.
+          <li>Run the <a>processing the <code>shortcuts</code> member</a> with
+          |manifest URL| and |manifest|.
           </li>
           <li>
             <a>Extension point</a>: process any proprietary and/or other
@@ -1963,21 +1962,20 @@
         <p>
           The steps for <dfn>processing the <code>shortcuts</code> member</dfn>
           are given by the following algorithm. The algorithm takes a
-          <a>sequence</a>&lt;<a>ShortcutItem</a>&gt; <var>shortcuts</var> and a
-          <a>URL</a> <var>manifest URL</var>. This algorithm returns a
-          <a>sequence</a>&lt;<a>ShortcutItem</a>&gt;.
+          <a>URL</a> <var>manifest URL</var>, and a |manifest:processed
+          manifest|.
         </p>
         <ol>
           <li>Let <var>processedShortcuts</var> be a new Array object created
           as if by the expression [].
           </li>
-          <li>For each <var>shortcut</var> (<a>ShortcutItem</a>) in the
-          sequence:
+          <li>[=list/For each=] {{ShortcutItem}} |shortcut:ShortItem| of
+          |shortcuts:sequence|:
             <ol>
-              <li>If <var>shortcut</var>["name"] or <var>shortcut</var>["url"]
-              are undefined, or if <var>shortcut</var>["name"] is the empty
-              string, <a>issue a developer warning</a> and
-              [=iteration/continue=].
+              <li>If |shortcut| is not an [=object=], or
+              <var>shortcut</var>["name"] or <var>shortcut</var>["url"] are
+              undefined, or <var>shortcut</var>["name"] is the empty string,
+              <a>issue a developer warning</a> and [=iteration/continue=].
               </li>
               <li>Set <var>shortcut</var>["icons"] to the result of running <a>
                 processing `ManifestImageResource` members</a> given
@@ -1988,8 +1986,8 @@
               URL</var> as the base URL. If the result is failure, <a>issue a
               developer warning</a> and [=iteration/continue=].
               </li>
-              <li>If <var>shortcut</var>["url"] is not [=URL/within scope=] of
-              <var>manifest URL</var>, <a>issue a developer warning</a> and
+              <li>If <var>shortcut</var>["url"] is not [=manifest/within
+              scope=] of |manifest|, <a>issue a developer warning</a> and
               [=iteration/continue=].
               </li>
               <li>
@@ -1998,7 +1996,7 @@
               </li>
             </ol>
           </li>
-          <li>Return <var>processedShortcuts</var>.
+          <li>Set |manifest|["shortcuts"] to <var>processedShortcuts</var>.
           </li>
         </ol>
         <p>


### PR DESCRIPTION
Closes #885 

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [X] Adds new normative requirements
* [ ] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Implementation commitment (delete if not making normative changes):

* [ ] Safari (link to issue)
* [ ] Chrome (link to issue)
* [ ] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1582341)
* [ ] Edge (public signal)

Commit message:

(Fill in. If making normative changes, describe exactly what the behavioral
difference will be.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/908.html" title="Last updated on Jun 26, 2020, 5:35 AM UTC (d10e522)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/908/59ecaa8...d10e522.html" title="Last updated on Jun 26, 2020, 5:35 AM UTC (d10e522)">Diff</a>