### PR TITLE
Editorial: include JSON Schema into spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -2969,9 +2969,9 @@
       </h2>
       <p>
         Developers interested in validating <a>manifest</a> documents can find
-        an unofficial <a href="http://json.schemastore.org/web-manifest">JSON
+        an unofficial <a href="https://json.schemastore.org/web-manifest">JSON
         schema for the manifest format</a> at <a href=
-        "http://schemastore.org/json/">schemastore.org</a>. It is licensed
+        "https://schemastore.org/json/">schemastore.org</a>. It is licensed
         under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache
         2.0</a>. It is kindly maintained by <a href=
         "https://github.com/madskristensen">Mads Kristensen</a>. If you find
@@ -2980,6 +2980,12 @@
         the <a href="https://github.com/SchemaStore/schemastore">SchemaStore
         repository</a> on GitHub.
       </p>
+      <aside class="note" title="">
+        <details>
+          <summary>Web Manifest JSON Schema</summary>
+          <pre class="json" data-include="https://json.schemastore.org/web-manifest"></pre>
+        </details>
+      </aside>
     </section>
     <section id="internationalization" class="appendix informative">
       <h2>


### PR DESCRIPTION
Relates to #611 - we add the JSON schema as a non-normative note to describe the structure and types 

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:
Takes a snapshot of the JSON schema and adds it directly into the spec as a non-normative note.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/928.html" title="Last updated on Jul 20, 2020, 8:50 AM UTC (f168e74)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/928/96246fb...f168e74.html" title="Last updated on Jul 20, 2020, 8:50 AM UTC (f168e74)">Diff</a>