### PR TITLE
Fix related_applications parsing instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1569,7 +1569,7 @@
           <li>[=list/For each=] <var>app</var> of <var>related
           applications</var>:
             <ol>
-              <li>if neither <var>app</var>["src"] nor <var>app</var>["url"]
+              <li>if neither <var>app</var>["id"] nor <var>app</var>["url"]
               are <code>undefined</code>:
                 <ol>
                   <li>Set <var>app</var>["url"] to the result of running


### PR DESCRIPTION
The instructions mentioned a src field which does not exist. Replace it with the id field.

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

Fix related_applications parsing instructions to refer to "id" instead of "src" (which doesn't exist).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfredwells/manifest/pull/933.html" title="Last updated on Oct 19, 2020, 8:01 AM UTC (0d68ff8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/933/7a7e212...benfredwells:0d68ff8.html" title="Last updated on Oct 19, 2020, 8:01 AM UTC (0d68ff8)">Diff</a>