### PR TITLE
Editorial: Created explicit algorithm for choosing display mode, and add extension point for the display_override incubation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
         </pre>
         <p>
           The following shows a <a>manifest</a> that prefers the <code>
-          minimal-ui</code> <a data-link-for="DisplayModeType">display mode</a>
+          minimal-ui</code> {{DisplayModeType}}
           to <code>standalone</code>, but wants to support both.
         </p>
         <pre class="example json" title="Advanced display requirements manifest">
@@ -213,7 +213,7 @@
             }],
             "start_url": "/index.html",
             "display_override": ["minimal-ui", "standalone"],
-            "display": "browser",
+            "display": "minimal-ui",
             "theme_color": "yellow",
             "background_color": "red"
           }
@@ -575,85 +575,88 @@
         mode</a>.
       </p>
       <p>
-        Each <a>display mode</a>, except <code>browser</code>, has a
-        <dfn>fallback display mode</dfn>, which is the <a>display mode</a> that
-        the user agent can try to use if it doesn't support a particular
-        <a>display mode</a>. If the user agent does support a <a>fallback
-        display mode</a>, then it checks to see if it can use that <a>display
-        mode</a>'s <a>fallback display mode</a>. This creates a fallback chain,
-        with the <a>default display mode</a> (<code>browser</code>) being the
-        last item in the chain.
+        For more advanced usages, the {{WebAppManifest/display_override}}
+        member can be used to specify a custom fallback order. This member is
+        valid IFF {{WebAppManifest/display}} is also present.
       </p>
       <p>
-        For more advanced usages, the <a data-link-for="WebAppManifest">
-        display_override</a> member can be used to specify a custom fallback
-        order. This member is valid IFF <a data-link-for="WebAppManifest">display</a> is also present.
-      </p>
-      <p>
-        The algorithm for determing the web app's requested display mode is:
+        The steps for determing the web app's requested display mode is given
+        by the following algorithm. The algorithm takes a
+        [=processed manifest=] |manifest:processed manifest| and returns a
+        [=display mode=].
         <ol>
-          <li>[=list/For each=] <var>considering_display_mode</var> of <var>
-            <a data-link-for="WebAppManifest">display_override</a></var>:
+          <li>
+            [=list/For each=] |candidate_display_mode:DisplayModeType| of
+            |manifest|.{{WebAppManifest/display_override}}:
             <ol>
               <li>
-                If the user agent supports the |considering_display_mode|,
-                then that display mode is used (exit).
+                If the user agent supports the |candidate_display_mode|, then
+                return |candidate_display_mode|.
               </li>
             </ol>
           </li>
           <li>
-            Let |considering_display_mode| be the the value specified by the
-            <a data-link-for="WebAppManifest">display</a> property.
+            Let |candidate_display_mode| be the the value specified by the
+            |manifest|.{{WebAppManifest/display}} property.
           </li>
           <li>
-            If the user agent supports the |considering_display_mode|, then
-            that display mode is used (exit).
+            [=iteration/while=] |considering_display_mode| is not {{browser}}
+            <ol>
+              <li>
+                If the user agent supports the |candidate_display_mode|, then
+                return |candidate_display_mode|.
+              </li>
+              <li>
+                If |candidate_display_mode| is
+                <a data-link-for="DisplayModeType">minimal-ui</a>, set
+                |candidate_display_mode| to {{browser}}.
+              </li>
+              <li>
+                If |candidate_display_mode| is {{standalone}}, set
+                |candidate_display_mode| to <a data-link-for="DisplayModeType">
+                minimal-ui</a>.
+              </li>
+              <li>
+                If |candidate_display_mode| is {{fullscreen}}, set
+                |candidate_display_mode| to {{standalone}}.
+              </li>
+            </ol>
           </li>
           <li>
-            While |considering_display_mode| has <a>fallback display mode</a>,
-            assign that to |considering_display_mode| and go back to step 3.
+            Return |candidate_display_mode|.
           </li>
         </ol>
-        This algorithm will end with the final <a>fallback display mode</a> of
-        <code>browser</code>, which the user agent MUST support.
-      </p>
       </p>
       <div class="example">
         <p>
-          Example: SuperSecure Browser (a fictitious browser) only supports
-          the <code>minimal-ui</code> and <code>browser</code> display modes,
+          SuperSecure Browser (a fictitious browser) only supports the
+          <code>minimal-ui</code> and <code>browser</code> display modes,
           but a developer declares that she wants <code>fullscreen</code> in
-          the manifest by using the <a data-link-for="WebAppManifest">display
-          </a> property. In this case, the user agent will first check if it
-          supports <code>fullscreen</code> (it doesn't), so it falls back to
+          the manifest by using the {{WebAppManifest/display}} property. In
+          this case, the user agent will first check if it supports
+          <code>fullscreen</code> (it doesn't), so it falls back to
           <code>standalone</code> (which it also doesn't support), and
           ultimately falls back to <code>minimal-ui</code>.
         </p>
       </div>
       <div class="example">
         <p>
-          Example: Same browser as above (SuperSecure Browser),
-          but the developer instead specified the following manifest using
-          display_override:
+          Same browser as above (SuperSecure Browser), but the developer
+          instead specified the following manifest using display_override:
           <pre class="example json" title="Using display_override">
             {
               display_override: ["fullscreen"],
               display: "browser"
             }
           </pre>
-          This declares that she only wants <code>fullscreen</code>, and if
-          that is not supported, then fall back to <code>browser</code>. The
-          user agent processes the <a data-link-for="WebAppManifest">
-          display_override</a> field and does not support <code>fullscreen
-          </code>, so it falls back to processing the
-          <a data-link-for="WebAppManifest">display</a> property, resulting in
-          the <code>browser</code> display mode.
+          This declares that the user agent should use |fullscreen|, and if
+          that is not supported, it should fall back to |browser| without
+          considering the other modes.
         </p>
       </div>
       <p>
         The <dfn>display modes values</dfn> defined by
-        <dfn>DisplayModeType</dfn>, and their corresponding <a>fallback display
-        modes</a> are as follows:
+        <dfn>DisplayModeType</dfn>:
       </p>
       <dl>
         <dt>
@@ -662,10 +665,6 @@
         <dd>
           Opens the web application without any user agent chrome and takes up
           the entirety of the available display area.
-        </dd>
-        <dd>
-          The <a>fallback display mode</a> for <code>fullscreen</code> is
-          <code>standalone</code>.
         </dd>
         <dt>
           <dfn>standalone</dfn>
@@ -678,10 +677,6 @@
           URL bar, but can include other system UI elements such as a status
           bar and/or system back button.
         </dd>
-        <dd>
-          The <a>fallback display mode</a> for <code>standalone</code> is
-          <code>minimal-ui</code>.
-        </dd>
         <dt>
           <dfn>minimal-ui</dfn>
         </dt>
@@ -693,10 +688,6 @@
           other platform specific UI elements, such as "share" and "print"
           buttons or whatever is customary on the platform and user agent.
         </dd>
-        <dd>
-          The <a>fallback display mode</a> for <code>minimal-ui</code> is
-          <code>browser</code>.
-        </dd>
         <dt>
           <dfn>browser</dfn>
         </dt>
@@ -706,9 +697,8 @@
           window).
         </dd>
         <dd>
-          The <code>browser</code> <a>display mode</a> doesn't have a
-          <a>fallback display mode</a> (conforming user agents are required to
-          support the <code>browser</code> <a>display mode</a>).
+          Conforming user agents are required to
+          support the <code>browser</code> <a>display mode</a>.
         </dd>
       </dl>
       <p class="note">
@@ -1085,6 +1075,7 @@
              sequence&lt;ManifestImageResource&gt; icons;
              USVString start_url;
              DisplayModeType display = "browser";
+             sequence&lt;DisplayModeType&gt; display_override;
              OrientationLockType orientation;
              USVString theme_color;
              USVString background_color;

--- a/index.html
+++ b/index.html
@@ -198,27 +198,6 @@
             "background_color": "red"
           }
         </pre>
-        <p>
-          The following shows a <a>manifest</a> that prefers the <code>
-          minimal-ui</code> [=display modes|display mode=]
-          to <code>standalone</code>, but if minimal-ui isn't supported, fall
-          back to standalone as opposed to browser.
-        </p>
-        <pre class="example json" title="Advanced display usage manifest">
-          {
-            "name": "Recipe Zone",
-            "description": "All of the recipes!",
-            "icons": [{
-              "src": "icon/hd_hi",
-              "sizes": "128x128"
-            }],
-            "start_url": "/index.html",
-            "display_override": ["minimal-ui"],
-            "display": "standalone",
-            "theme_color": "yellow",
-            "background_color": "red"
-          }
-        </pre>
       </section>
       <section class="informative">
         <h3>
@@ -596,24 +575,14 @@
         </ol>
       </p>
       <p>
-        For more advanced usages, the {{WebAppManifest/display_override}}
-        member can be used to specify a custom fallback order.
-      </p>
-      <p>
         The <dfn>steps for determing the web app's chosen display mode</dfn> is
         given by the following algorithm. The algorithm takes a
         [=processed manifest=] |manifest:processed manifest| and returns a
         [=display mode=].
         <ol>
           <li>
-            [=list/For each=] |candidate_display_mode:DisplayModeType| of
-            |manifest|.{{WebAppManifest/display_override}}:
-            <ol>
-              <li>
-                If the user agent supports the |candidate_display_mode|, then
-                return |candidate_display_mode|.
-              </li>
-            </ol>
+            <a>Extension point</a>: process any proprietary and/or other
+            supported display mode choosers at this point in the algorithm.
           </li>
           <li>
             [=list/For each=] |fallback_mode:DisplayModeType| of the
@@ -633,13 +602,6 @@
           [=fallback chain=], and the requirement that all user agents support
           the {{browser}} [=display mode=].
         </p>
-        <p class="note">
-          In the future, new values added to {{DisplayModeType}} will not be
-          added to the [=fallback chain=], and the algorithm should treat these
-          values, when used with the {{WebAppManifest/display}} field, as
-          {{browser}}. New values will only be compatible with
-          {{WebAppManifest/display_override}}.
-        </p>
       </p>
       <div class="example">
         <p>
@@ -651,20 +613,6 @@
           <code>fullscreen</code> (it doesn't), so it falls back to
           <code>standalone</code> (which it also doesn't support), and
           ultimately falls back to <code>minimal-ui</code>.
-        </p>
-      </div>
-      <div class="example">
-        <p>
-          Same browser as above (SuperSecure Browser), but the developer
-          instead specified the following manifest using display_override:
-          <pre class="example json" title="Using display_override">
-            {
-              display_override: ["fullscreen", "browser"]
-            }
-          </pre>
-          This declares that the user agent should use |fullscreen|, and if
-          that is not supported, it should fall back to |browser| without
-          considering the other modes.
         </p>
       </div>
       <p>
@@ -1084,7 +1032,6 @@
              sequence&lt;ManifestImageResource&gt; icons;
              USVString start_url;
              DisplayModeType display = "browser";
-             sequence&lt;DisplayModeType&gt; display_override;
              OrientationLockType orientation;
              USVString theme_color;
              USVString background_color;
@@ -1401,25 +1348,6 @@
           The <dfn>display</dfn> member is a <a>DisplayModeType</a>, whose
           value is one of <a>display modes values</a>. The item represents the
           developer's preferred <a>display mode</a> for the web application.
-        </p>
-      </section>
-      <section>
-        <h3>
-          <code>display_override</code> member
-        </h3>
-        <p>
-          The <dfn>display_override</dfn> member is a <a>sequence</a> of<a>
-          DisplayModeType</a>. This item represents the developer's preferred
-          fallback chain for [=display modes=]. This field overrides the
-          {{display}} property. If the user agent does not support any of the
-          display modes specified here, then it falls back to considering the
-          {{display}} field. See [=display modes=] for the algorithm steps.
-        </p>
-        <p class="note">
-          This member is intended to be only used for advanced cases, where
-          the developer wants explicit control over the fallback order of their
-          display modes. Otherwise, the {{display}} should be sufficient for
-          most use cases.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -564,6 +564,27 @@
         with the <a>default display mode</a> (<code>browser</code>) being the
         last item in the chain.
       </p>
+      <p>
+        For more advanced usages, the <a data-link-for="WebAppManifest">
+        display_override</a> member can be used to specify a custom fallback
+        order. This member is valid IFF <a data-link-for="WebAppManifest">display</a> is also present.
+      </p>
+      <p>
+        The algorithm for determing the web app's requested display mode is:
+        <ol>
+          <li>[=list/For each=] <var>considering_display_mode</var> of <var><a data-link-for="WebAppManifest">
+            display_override</a></var>:
+            <ol>
+              <li>If the user agent supports the |considering_display_mode|, then that display mode is used (exit).</li>
+            </ol>
+          </li>
+          <li>Let |considering_display_mode| be the the value specified by the <a data-link-for="WebAppManifest">display</a> property.</li>
+          <li>If the user agent supports the |considering_display_mode|, then that display mode is used (exit).</li>
+          <li>While |considering_display_mode| has <a>fallback display mode</a>, assign that to |considering_display_mode| and go back to step 3.</li>
+        </ol>
+        This algorithm will end with the final <a>fallback display mode</a> of <code>browser</code>, which the user agent MUST support.
+      </p>
+      </p>
       <div class="example">
         <p>
           For example, SuperSecure Browser (a fictitious browser) only supports
@@ -1326,6 +1347,20 @@
           The <dfn>display</dfn> member is a <a>DisplayModeType</a>, whose
           value is one of <a>display modes values</a>. The item represents the
           developer's preferred <a>display mode</a> for the web application.
+        </p>
+      </section>
+      <section>
+        <h3>
+          <code>display_override</code> member
+        </h3>
+        <p>
+          The <dfn>display_override</dfn> member is a <a>sequence</a> of<a>
+          DisplayModeType</a>. This item represents the developer's preferred
+          fallback chain for display modes. This field overrides the
+          <a data-link-for="WebAppManifest">display</a> property. If the user
+          agent does not support any of the display modes specified here, then
+          it falls back to considering the <a data-link-for="WebAppManifest">
+          display</a> field (and its corresponding fallback chain).
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -576,12 +576,32 @@
         mode</a>.
       </p>
       <p>
+        The fallback chain for:
+        <ol>
+          <li>
+            {{browser}} is «{{browser}}».
+          </li>
+          <li>
+            <a data-link-for="DisplayModeType">minimal-ui</a> is «
+            <a data-link-for="DisplayModeType">minimal-ui</a>, {{browser}}».
+          </li>
+          <li>
+            {{standalone}} is «{{standalone}},
+            <a data-link-for="DisplayModeType">minimal-ui</a>, {{browser}}».
+          </li>
+          <li>
+            {{fullscreen}} is «{{fullscreen}}, {{standalone}},
+            <a data-link-for="DisplayModeType">minimal-ui</a>, {{browser}}».
+          </li>
+        </ol>
+      </p>
+      <p>
         For more advanced usages, the {{WebAppManifest/display_override}}
         member can be used to specify a custom fallback order.
       </p>
       <p>
-        The steps for determing the web app's chosen display mode is given
-        by the following algorithm. The algorithm takes a
+        The <dfn>steps for determing the web app's chosen display mode</dfn> is
+        given by the following algorithm. The algorithm takes a
         [=processed manifest=] |manifest:processed manifest| and returns a
         [=display mode=].
         <ol>
@@ -596,30 +616,8 @@
             </ol>
           </li>
           <li>
-            Define the |fallback_chain| for {{browser}} to be [{{browser}}]
-          </li>
-          <li>
-            Define the |fallback_chain| for <a data-link-for="DisplayModeType">
-            minimal-ui</a> to be [<a data-link-for="DisplayModeType">minimal-ui
-            </a>, {{browser}}]
-          </li>
-          <li>
-            Define the |fallback_chain| for {{standalone}} to be [
-            {{standalone}}, <a data-link-for="DisplayModeType">minimal-ui</a>,
-            {{browser}}]
-          </li>
-          <li>
-            Define the |fallback_chain| for {{fullscreen}} to be [
-            {{fullscreen}}, {{standalone}}, <a data-link-for="DisplayModeType">
-            minimal-ui</a>, {{browser}}]
-          </li>
-          <li>
-            Let |candidate_display_mode| be the the value specified by the
-            |manifest|.{{WebAppManifest/display}} property.
-          </li>
-          <li>
             [=list/For each=] |fallback_mode:DisplayModeType| of the
-            |fallback_chain| of the |candidate_display_mode|:
+            fallback_chain of |manifest|.{{WebAppManifest/display}}:
             <ol>
               <li>
                 If the user agent supports the |fallback_mode|, then
@@ -628,6 +626,12 @@
             </ol>
           </li>
         </ol>
+        <p class="note">
+          The above loop is guaranteed to return a value before it terminates,
+          due to the fact that {{browser}} is in every mode's fallback chain,
+          and the requirement that all user agents support the {{browser}} [=display
+          mode=].
+        </p>
       </p>
       <div class="example">
         <p>
@@ -696,10 +700,6 @@
           Opens the web application using the platform-specific convention for
           opening hyperlinks in the user agent (e.g., in a browser tab or a new
           window).
-        </dd>
-        <dd>
-          Conforming user agents are required to
-          support the <code>browser</code> <a>display mode</a>.
         </dd>
       </dl>
       <p class="note">

--- a/index.html
+++ b/index.html
@@ -555,32 +555,35 @@
         mode</a>.
       </p>
       <p>
-        The <dfn>fallback chain</dfn> for:
+        Every [=display mode=] has a <dfn>fallback chain</dfn>, which is a list
+        of [=display modes=]. The [=fallback chain=] for:
       </p>
       <ol>
-        <li>{{browser}} is «{{browser}}».
+        <li>{{browser}} is «».
         </li>
         <li>
-          <a data-link-for="DisplayModeType">minimal-ui</a> is «
-          <a data-link-for="DisplayModeType">minimal-ui</a>, {{browser}}».
+          <a data-link-for="DisplayModeType">minimal-ui</a> is «{{browser}}».
         </li>
-        <li>{{standalone}} is «{{standalone}}, <a data-link-for=
+        <li>{{standalone}} is «<a data-link-for=
         "DisplayModeType">minimal-ui</a>, {{browser}}».
         </li>
-        <li>{{fullscreen}} is «{{fullscreen}}, {{standalone}},
-          <a data-link-for="DisplayModeType">minimal-ui</a>, {{browser}}».
+        <li>{{fullscreen}} is «{{standalone}}, <a data-link-for=
+        "DisplayModeType">minimal-ui</a>, {{browser}}».
         </li>
       </ol>
       <p>
-        The <dfn>steps for determing the web app's chosen display mode</dfn> is
-        given by the following algorithm. The algorithm takes a [=processed
+        The <dfn>steps for determining the web app's chosen display mode</dfn>
+        is given by the following algorithm. The algorithm takes a [=processed
         manifest=] |manifest:processed manifest| and returns a [=display
         mode=].
       </p>
       <ol>
         <li>
           <a>Extension point</a>: process any proprietary and/or other
-          supported display mode choosers at this point in the algorithm.
+          supported display modes at this point in the algorithm.
+        </li>
+        <li>If the user agent supports |manifest|.{{WebAppManifest/display}},
+        then return |manifest|.{{WebAppManifest/display}}.
         </li>
         <li>[=list/For each=] |fallback_mode:DisplayModeType| of the [=fallback
         chain=] of |manifest|.{{WebAppManifest/display}}:

--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
             "theme_color": "aliceblue",
             "background_color": "red"
           }
-        </pre>
+      </pre>
       </section>
       <section class="informative">
         <h3>

--- a/index.html
+++ b/index.html
@@ -213,8 +213,8 @@
               "sizes": "128x128"
             }],
             "start_url": "/index.html",
-            "display_override": ["minimal-ui", "standalone"],
-            "display": "minimal-ui",
+            "display_override": ["minimal-ui"],
+            "display": "standalone",
             "theme_color": "yellow",
             "background_color": "red"
           }
@@ -617,7 +617,7 @@
           </li>
           <li>
             [=list/For each=] |fallback_mode:DisplayModeType| of the
-            fallback_chain of |manifest|.{{WebAppManifest/display}}:
+            fallback chain of |manifest|.{{WebAppManifest/display}}:
             <ol>
               <li>
                 If the user agent supports the |fallback_mode|, then
@@ -625,12 +625,20 @@
               </li>
             </ol>
           </li>
+          <li>[=Assert=] false.</li>
         </ol>
         <p class="note">
-          The above loop is guaranteed to return a value before it terminates,
+          The above loop is guaranteed to return a value before the assertion,
           due to the fact that {{browser}} is in every mode's fallback chain,
-          and the requirement that all user agents support the {{browser}} [=display
-          mode=].
+          and the requirement that all user agents support the {{browser}}
+          [=display mode=].
+        </p>
+        <p class="note">
+          In the future, new values added to {{DisplayModeType}} will not be
+          added to the fallback chain, and the algorithm should treat these
+          values, when used with the {{WebAppManifest/display}} field, as
+          {{browser}}. New values will only be compatible with
+          {{WebAppManifest/display_override}}.
         </p>
       </p>
       <div class="example">
@@ -1406,6 +1414,12 @@
           {{display}} property. If the user agent does not support any of the
           display modes specified here, then it falls back to considering the
           {{display}} field. See [=display modes=] for the algorithm steps.
+        </p>
+        <p class="note">
+          This member is intended to be only used for advanced cases, where
+          the developer wants explicit control over the fallback order of their
+          display modes. Otherwise, the {{display}} should be sufficient for
+          most use cases.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -200,10 +200,11 @@
         </pre>
         <p>
           The following shows a <a>manifest</a> that prefers the <code>
-          minimal-ui</code> {{DisplayModeType}}
-          to <code>standalone</code>, but wants to support both.
+          minimal-ui</code> [=display modes|display mode=]
+          to <code>standalone</code>, but if minimal-ui isn't supported, fall
+          back to standalone as opposed to browser.
         </p>
-        <pre class="example json" title="Advanced display requirements manifest">
+        <pre class="example json" title="Advanced display usage manifest">
           {
             "name": "Recipe Madness",
             "description": "All of the recipes!",
@@ -576,11 +577,10 @@
       </p>
       <p>
         For more advanced usages, the {{WebAppManifest/display_override}}
-        member can be used to specify a custom fallback order. This member is
-        valid IFF {{WebAppManifest/display}} is also present.
+        member can be used to specify a custom fallback order.
       </p>
       <p>
-        The steps for determing the web app's requested display mode is given
+        The steps for determing the web app's chosen display mode is given
         by the following algorithm. The algorithm takes a
         [=processed manifest=] |manifest:processed manifest| and returns a
         [=display mode=].
@@ -596,34 +596,36 @@
             </ol>
           </li>
           <li>
+            Define the |fallback_chain| for {{browser}} to be [{{browser}}]
+          </li>
+          <li>
+            Define the |fallback_chain| for <a data-link-for="DisplayModeType">
+            minimal-ui</a> to be [<a data-link-for="DisplayModeType">minimal-ui
+            </a>, {{browser}}]
+          </li>
+          <li>
+            Define the |fallback_chain| for {{standalone}} to be [
+            {{standalone}}, <a data-link-for="DisplayModeType">minimal-ui</a>,
+            {{browser}}]
+          </li>
+          <li>
+            Define the |fallback_chain| for {{fullscreen}} to be [
+            {{fullscreen}}, {{standalone}}, <a data-link-for="DisplayModeType">
+            minimal-ui</a>, {{browser}}]
+          </li>
+          <li>
             Let |candidate_display_mode| be the the value specified by the
             |manifest|.{{WebAppManifest/display}} property.
           </li>
           <li>
-            [=iteration/while=] |considering_display_mode| is not {{browser}}
+            [=list/For each=] |fallback_mode:DisplayModeType| of the
+            |fallback_chain| of the |candidate_display_mode|:
             <ol>
               <li>
-                If the user agent supports the |candidate_display_mode|, then
-                return |candidate_display_mode|.
-              </li>
-              <li>
-                If |candidate_display_mode| is
-                <a data-link-for="DisplayModeType">minimal-ui</a>, set
-                |candidate_display_mode| to {{browser}}.
-              </li>
-              <li>
-                If |candidate_display_mode| is {{standalone}}, set
-                |candidate_display_mode| to <a data-link-for="DisplayModeType">
-                minimal-ui</a>.
-              </li>
-              <li>
-                If |candidate_display_mode| is {{fullscreen}}, set
-                |candidate_display_mode| to {{standalone}}.
+                If the user agent supports the |fallback_mode|, then
+                return |fallback_mode|.
               </li>
             </ol>
-          </li>
-          <li>
-            Return |candidate_display_mode|.
           </li>
         </ol>
       </p>
@@ -645,8 +647,7 @@
           instead specified the following manifest using display_override:
           <pre class="example json" title="Using display_override">
             {
-              display_override: ["fullscreen"],
-              display: "browser"
+              display_override: ["fullscreen", "browser"]
             }
           </pre>
           This declares that the user agent should use |fullscreen|, and if
@@ -1401,11 +1402,10 @@
         <p>
           The <dfn>display_override</dfn> member is a <a>sequence</a> of<a>
           DisplayModeType</a>. This item represents the developer's preferred
-          fallback chain for display modes. This field overrides the
-          <a data-link-for="WebAppManifest">display</a> property. If the user
-          agent does not support any of the display modes specified here, then
-          it falls back to considering the <a data-link-for="WebAppManifest">
-          display</a> field (and its corresponding fallback chain).
+          fallback chain for [=display modes=]. This field overrides the
+          {{display}} property. If the user agent does not support any of the
+          display modes specified here, then it falls back to considering the
+          {{display}} field. See [=display modes=] for the algorithm steps.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -197,7 +197,27 @@
             "theme_color": "aliceblue",
             "background_color": "red"
           }
-      </pre>
+        </pre>
+        <p>
+          The following shows a <a>manifest</a> that prefers the <code>
+          minimal-ui</code> <a data-link-for="DisplayModeType">display mode</a>
+          to <code>standalone</code>, but wants to support both.
+        </p>
+        <pre class="example json" title="Advanced display requirements manifest">
+          {
+            "name": "Recipe Madness",
+            "description": "All of the recipes!",
+            "icons": [{
+              "src": "icon/hd_hi",
+              "sizes": "128x128"
+            }],
+            "start_url": "/index.html",
+            "display_override": ["minimal-ui", "standalone"],
+            "display": "browser",
+            "theme_color": "yellow",
+            "background_color": "red"
+          }
+        </pre>
       </section>
       <section class="informative">
         <h3>
@@ -572,28 +592,62 @@
       <p>
         The algorithm for determing the web app's requested display mode is:
         <ol>
-          <li>[=list/For each=] <var>considering_display_mode</var> of <var><a data-link-for="WebAppManifest">
-            display_override</a></var>:
+          <li>[=list/For each=] <var>considering_display_mode</var> of <var>
+            <a data-link-for="WebAppManifest">display_override</a></var>:
             <ol>
-              <li>If the user agent supports the |considering_display_mode|, then that display mode is used (exit).</li>
+              <li>
+                If the user agent supports the |considering_display_mode|,
+                then that display mode is used (exit).
+              </li>
             </ol>
           </li>
-          <li>Let |considering_display_mode| be the the value specified by the <a data-link-for="WebAppManifest">display</a> property.</li>
-          <li>If the user agent supports the |considering_display_mode|, then that display mode is used (exit).</li>
-          <li>While |considering_display_mode| has <a>fallback display mode</a>, assign that to |considering_display_mode| and go back to step 3.</li>
+          <li>
+            Let |considering_display_mode| be the the value specified by the
+            <a data-link-for="WebAppManifest">display</a> property.
+          </li>
+          <li>
+            If the user agent supports the |considering_display_mode|, then
+            that display mode is used (exit).
+          </li>
+          <li>
+            While |considering_display_mode| has <a>fallback display mode</a>,
+            assign that to |considering_display_mode| and go back to step 3.
+          </li>
         </ol>
-        This algorithm will end with the final <a>fallback display mode</a> of <code>browser</code>, which the user agent MUST support.
+        This algorithm will end with the final <a>fallback display mode</a> of
+        <code>browser</code>, which the user agent MUST support.
       </p>
       </p>
       <div class="example">
         <p>
-          For example, SuperSecure Browser (a fictitious browser) only supports
+          Example: SuperSecure Browser (a fictitious browser) only supports
           the <code>minimal-ui</code> and <code>browser</code> display modes,
           but a developer declares that she wants <code>fullscreen</code> in
-          the manifest. In this case, the user agent will first check if it
+          the manifest by using the <a data-link-for="WebAppManifest">display
+          </a> property. In this case, the user agent will first check if it
           supports <code>fullscreen</code> (it doesn't), so it falls back to
           <code>standalone</code> (which it also doesn't support), and
           ultimately falls back to <code>minimal-ui</code>.
+        </p>
+      </div>
+      <div class="example">
+        <p>
+          Example: Same browser as above (SuperSecure Browser),
+          but the developer instead specified the following manifest using
+          display_override:
+          <pre class="example json" title="Using display_override">
+            {
+              display_override: ["fullscreen"],
+              display: "browser"
+            }
+          </pre>
+          This declares that she only wants <code>fullscreen</code>, and if
+          that is not supported, then fall back to <code>browser</code>. The
+          user agent processes the <a data-link-for="WebAppManifest">
+          display_override</a> field and does not support <code>fullscreen
+          </code>, so it falls back to processing the
+          <a data-link-for="WebAppManifest">display</a> property, resulting in
+          the <code>browser</code> display mode.
         </p>
       </div>
       <p>

--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
         </p>
         <pre class="example json" title="Advanced display usage manifest">
           {
-            "name": "Recipe Madness",
+            "name": "Recipe Zone",
             "description": "All of the recipes!",
             "icons": [{
               "src": "icon/hd_hi",
@@ -576,7 +576,7 @@
         mode</a>.
       </p>
       <p>
-        The fallback chain for:
+        The <dfn>fallback chain</dfn> for:
         <ol>
           <li>
             {{browser}} is «{{browser}}».
@@ -617,7 +617,7 @@
           </li>
           <li>
             [=list/For each=] |fallback_mode:DisplayModeType| of the
-            fallback chain of |manifest|.{{WebAppManifest/display}}:
+            [=fallback chain=] of |manifest|.{{WebAppManifest/display}}:
             <ol>
               <li>
                 If the user agent supports the |fallback_mode|, then
@@ -629,13 +629,13 @@
         </ol>
         <p class="note">
           The above loop is guaranteed to return a value before the assertion,
-          due to the fact that {{browser}} is in every mode's fallback chain,
-          and the requirement that all user agents support the {{browser}}
-          [=display mode=].
+          due to the fact that {{browser}} is in every mode's
+          [=fallback chain=], and the requirement that all user agents support
+          the {{browser}} [=display mode=].
         </p>
         <p class="note">
           In the future, new values added to {{DisplayModeType}} will not be
-          added to the fallback chain, and the algorithm should treat these
+          added to the [=fallback chain=], and the algorithm should treat these
           values, when used with the {{WebAppManifest/display}} field, as
           {{browser}}. New values will only be compatible with
           {{WebAppManifest/display_override}}.

--- a/index.html
+++ b/index.html
@@ -556,60 +556,56 @@
       </p>
       <p>
         The <dfn>fallback chain</dfn> for:
-        <ol>
-          <li>
-            {{browser}} is «{{browser}}».
-          </li>
-          <li>
-            <a data-link-for="DisplayModeType">minimal-ui</a> is «
-            <a data-link-for="DisplayModeType">minimal-ui</a>, {{browser}}».
-          </li>
-          <li>
-            {{standalone}} is «{{standalone}},
-            <a data-link-for="DisplayModeType">minimal-ui</a>, {{browser}}».
-          </li>
-          <li>
-            {{fullscreen}} is «{{fullscreen}}, {{standalone}},
-            <a data-link-for="DisplayModeType">minimal-ui</a>, {{browser}}».
-          </li>
-        </ol>
       </p>
+      <ol>
+        <li>{{browser}} is «{{browser}}».
+        </li>
+        <li>
+          <a data-link-for="DisplayModeType">minimal-ui</a> is «
+          <a data-link-for="DisplayModeType">minimal-ui</a>, {{browser}}».
+        </li>
+        <li>{{standalone}} is «{{standalone}}, <a data-link-for=
+        "DisplayModeType">minimal-ui</a>, {{browser}}».
+        </li>
+        <li>{{fullscreen}} is «{{fullscreen}}, {{standalone}},
+          <a data-link-for="DisplayModeType">minimal-ui</a>, {{browser}}».
+        </li>
+      </ol>
       <p>
         The <dfn>steps for determing the web app's chosen display mode</dfn> is
-        given by the following algorithm. The algorithm takes a
-        [=processed manifest=] |manifest:processed manifest| and returns a
+        given by the following algorithm. The algorithm takes a [=processed
+        manifest=] |manifest:processed manifest| and returns a [=display
+        mode=].
+      </p>
+      <ol>
+        <li>
+          <a>Extension point</a>: process any proprietary and/or other
+          supported display mode choosers at this point in the algorithm.
+        </li>
+        <li>[=list/For each=] |fallback_mode:DisplayModeType| of the [=fallback
+        chain=] of |manifest|.{{WebAppManifest/display}}:
+          <ol>
+            <li>If the user agent supports the |fallback_mode|, then return
+            |fallback_mode|.
+            </li>
+          </ol>
+        </li>
+        <li>[=Assert=] false.
+        </li>
+      </ol>
+      <p class="note">
+        The above loop is guaranteed to return a value before the assertion,
+        due to the fact that {{browser}} is in every mode's [=fallback chain=],
+        and the requirement that all user agents support the {{browser}}
         [=display mode=].
-        <ol>
-          <li>
-            <a>Extension point</a>: process any proprietary and/or other
-            supported display mode choosers at this point in the algorithm.
-          </li>
-          <li>
-            [=list/For each=] |fallback_mode:DisplayModeType| of the
-            [=fallback chain=] of |manifest|.{{WebAppManifest/display}}:
-            <ol>
-              <li>
-                If the user agent supports the |fallback_mode|, then
-                return |fallback_mode|.
-              </li>
-            </ol>
-          </li>
-          <li>[=Assert=] false.</li>
-        </ol>
-        <p class="note">
-          The above loop is guaranteed to return a value before the assertion,
-          due to the fact that {{browser}} is in every mode's
-          [=fallback chain=], and the requirement that all user agents support
-          the {{browser}} [=display mode=].
-        </p>
       </p>
       <div class="example">
         <p>
           SuperSecure Browser (a fictitious browser) only supports the
-          <code>minimal-ui</code> and <code>browser</code> display modes,
-          but a developer declares that she wants <code>fullscreen</code> in
-          the manifest by using the {{WebAppManifest/display}} property. In
-          this case, the user agent will first check if it supports
+          <code>minimal-ui</code> and <code>browser</code> display modes, but a
+          developer declares that she wants <code>fullscreen</code> in the
+          manifest by using the {{WebAppManifest/display}} property. In this
+          case, the user agent will first check if it supports
           <code>fullscreen</code> (it doesn't), so it falls back to
           <code>standalone</code> (which it also doesn't support), and
           ultimately falls back to <code>minimal-ui</code>.


### PR DESCRIPTION
This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

Editorial: Created explicit algorithm for choosing display mode, and add extension point for the display_override incubation.

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* editorial:


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dmurph/manifest/pull/949.html" title="Last updated on Feb 18, 2021, 2:55 AM UTC (46466c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/949/0f2fd13...dmurph:46466c9.html" title="Last updated on Feb 18, 2021, 2:55 AM UTC (46466c9)">Diff</a>