### PR TITLE
Editorial: clarify what document URL is

### DIFF
--- a/index.html
+++ b/index.html
@@ -995,6 +995,11 @@
             [=Response=] |response|.
           </p>
           <ol class="algorithm">
+            <li>Let |document URL:URL| be |el|'s [=Node/node document=]'s
+            [=Document/URL=].
+            </li>
+            <li>Assert: |document URL:URL| is not null.
+            </li>
             <li>Let |json| be the result of [=parse JSON from bytes=]
             |response|'s [=response/body=].
             </li>
@@ -1025,7 +1030,7 @@
             "short_name".
             </li>
             <li>[=Process the `start_url` member=] passing |json|, |manifest|,
-            |manifest URL|, and <var>document URL</var>.
+            |manifest URL|, and |document URL|.
             </li>
             <li>[=Process the `scope` member=] passing |json|, |manifest|, and
             |manifest URL|.


### PR DESCRIPTION
Closes #946

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:
Clarify that the document URL is coming from the link element's owner document and that it won't be null.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/959.html" title="Last updated on Mar 15, 2021, 4:58 AM UTC (ee05814)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/959/5a3e8ec...ee05814.html" title="Last updated on Mar 15, 2021, 4:58 AM UTC (ee05814)">Diff</a>