### PR TITLE
Editorial: remove word 'chrome' when talking about fullscreen

### DIFF
--- a/index.html
+++ b/index.html
@@ -2248,8 +2248,8 @@
           "<dfn>fullscreen</dfn>"
         </dt>
         <dd>
-          Opens the web application without any user agent chrome and takes up
-          the entirety of the available display area.
+          Opens the web application with browser UI elements hidden and takes
+          up the entirety of the available display area.
         </dd>
         <dt>
           "<dfn>standalone</dfn>"


### PR DESCRIPTION
Closes #934

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

If change is normative, and it adds or changes a member:

Removes the word "chrome", as requested by @mgiuca in https://github.com/w3c/manifest/issues/934#issuecomment-716313961


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/960.html" title="Last updated on Apr 7, 2021, 12:28 AM UTC (487039a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/960/04b2157...487039a.html" title="Last updated on Apr 7, 2021, 12:28 AM UTC (487039a)">Diff</a>