### PR TITLE
Remove query & fragment components from scope URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -569,8 +569,11 @@
           </li>
           <li>If |scope| is failure, return.
           </li>
-          <li>If |manifest|["start_url"] is not [=URL/within scope=] of |scope
-          URL|, return.
+          <li>From |scope|, remove the [=url/query=] and [=url/fragment=]
+          components.
+          </li>
+          <li>If |manifest|["start_url"] is not [=URL/within scope=] of
+          |scope|, return.
           </li>
           <li>Otherwise, set |manifest|["scope"] to |scope|.
           </li>


### PR DESCRIPTION
Closes #793

This change (choose at least one, delete ones that don't apply):

* Adds new normative requirements

Implementation commitment (delete if not making normative changes):

* [ ] Safari (link to issue)
* [ ] Chrome (link to issue)
* [x] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1697089)
* [ ] Edge (public signal)

Commit message:

When the scope URL is created, the query and fragment components are removed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/961.html" title="Last updated on Apr 7, 2021, 12:26 AM UTC (7170a48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/961/5a3e8ec...7170a48.html" title="Last updated on Apr 7, 2021, 12:26 AM UTC (7170a48)">Diff</a>