### PR TITLE
Editorial: remove installability signals

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,8 +206,7 @@
         <p>
           Although it is optional for any member to appear in a manifest, some
           user agents might require one or more to be present to take full
-          advantage of the capabilities afforded by this specification (see
-          [[[#installability-signals]]]).
+          advantage of the capabilities afforded by this specification.
         </p>
       </aside>
       <section class="informative">
@@ -1937,11 +1936,6 @@
         and again as an example, the user agent could <a>install</a> the web
         application into a list of bookmarks within the user agent itself.
       </p>
-      <p>
-        A [=document=] <dfn data-dfn-for="document">is installable</dfn> if
-        it's a [=top-level browsing context=] and the user agent deems it to be
-        installable (e.g., see [[[#installability-signals]]]).
-      </p>
       <section>
         <h3>
           Application's name
@@ -1998,47 +1992,6 @@
           linked to from the manifest (for example, icons) after a web
           application is <a>installed</a> - or by using an entirely different
           cache from that used for regular web browsing.
-        </p>
-      </section>
-      <section class="informative">
-        <h3 id="installability-signals">
-          Installability signals
-        </h3>
-        <p>
-          By design, this specification does not provide developers with an
-          explicit API to "install" a web application. Instead, a
-          <a>manifest</a> can serve as an <dfn>installability signal</dfn> to a
-          user agent that a web application can be <a>installed</a>.
-        </p>
-        <p>
-          Examples of <a>installability signals</a> for a web application:
-        </p>
-        <ul>
-          <li>has a <a>manifest</a> with at least a [=manifest/name=] member
-          and a suitable icon (e.g., of a particular format and of a minimum
-          width/height).
-          </li>
-          <li>is served over a secure network connection.
-          </li>
-          <li>has a sensible content security policy.
-          </li>
-          <li>is able to responsively adapt to display on a variety of screen
-          sizes, catering for both mobile and desktop.
-          </li>
-          <li>is able to function without a network connection.
-          </li>
-          <li>is repeatedly used by the end-user over some extended period of
-          time.
-          </li>
-          <li>has been explicitly marked by the user as one that they value and
-          trust (e.g., by bookmarking or "starring" it).
-          </li>
-        </ul>
-        <p>
-          This list is not exhaustive and some <a>installability signals</a>
-          might not apply to all user agents. How a user agent makes use of
-          these <a>installability signals</a> to determine if a web application
-          can be <a>installed</a> is left to implementers.
         </p>
       </section>
       <section>


### PR DESCRIPTION
This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

The installability signals didn't really catch on (at least, in the overly broad way currently outlined in the spec). So, for spec brevity, I'm proposing we remove them as they are in an implementation detail.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/966.html" title="Last updated on Apr 7, 2021, 12:30 AM UTC (bc11361)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/966/9197eed...bc11361.html" title="Last updated on Apr 7, 2021, 12:30 AM UTC (bc11361)">Diff</a>