### PR TITLE
Add missing shortcut icon in the list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1642,6 +1642,8 @@
         </li>
         <li>[=shortcut item/url=]
         </li>
+        <li>[=shortcut item/icon=]
+        </li>
       </ul>
       <p>
         A user agent can use these members to assemble a context menu to be


### PR DESCRIPTION
Adds the missing `"icons"` member to the shortcut member list.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/979.html" title="Last updated on Jun 1, 2021, 10:53 AM UTC (11677cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/979/bd31a36...11677cf.html" title="Last updated on Jun 1, 2021, 10:53 AM UTC (11677cf)">Diff</a>