### PR TITLE
Editorial: Fix shortcut icons grammar

### DIFF
--- a/index.html
+++ b/index.html
@@ -1702,8 +1702,8 @@
         </h3>
         <p>
           The <a>shortcut item</a>'s <code><dfn data-dfn-for=
-          "shortcut item">icons</dfn></code> member serve as iconic
-          representations of the shortcut in various contexts.
+          "shortcut item">icons</dfn></code> member lists images that serve
+          as iconic representations of the shortcut in various contexts.
         </p>
       </section>
       <section>


### PR DESCRIPTION
Fix grammar for shortcut icons.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/981.html" title="Last updated on Jun 2, 2021, 7:53 AM UTC (276935f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/981/22c68c6...276935f.html" title="Last updated on Jun 2, 2021, 7:53 AM UTC (276935f)">Diff</a>