### PR TITLE
Use docURL as start_url

### DIFF
--- a/index.html
+++ b/index.html
@@ -767,9 +767,6 @@
           <li>If |json|["start_url"] doesn't [=map/exist=] or
           |json|["start_url"] is not a [=string=], return.
           </li>
-          <li>Set |manifest|["start_url"] to the result of [=URL
-          Parser|parsing=] |docHref|.
-          </li>
           <li>If the type of |json|["start_url"] is not [=string=], or if
           |json|["start_url"] is the empty string, return.
           </li>

--- a/index.html
+++ b/index.html
@@ -767,7 +767,11 @@
           <li>If |json|["start_url"] doesn't [=map/exist=] or
           |json|["start_url"] is not a [=string=], return.
           </li>
-          <li>If |json|["start_url"] is the empty string, return.
+          <li>Set |manifest|["start_url"] to the result of [=URL
+          Parser|parsing=] |docHref|.
+          </li>
+          <li>If the type of |json|["start_url"] is not [=string=], or if
+          |json|["start_url"] is the empty string, return.
           </li>
           <li>Let |start URL:URL| be the result of [=URL Parser|parsing=]
           |json|["start_url"], using |manifest URL| as the base URL.


### PR DESCRIPTION
Closes #669
Closes #668 
Closes #670
Closes #834

This change (choose at least one, delete ones that don't apply):

* Adds new normative requirements

Implementation commitment (delete if not making normative changes):

* [X] WebKit - already implemented
* [X] Chromium - already implemented
* [X] Gecko - already implemented

Commit message:

Reflect that user agents are using the document's URL as the start URL.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/991.html" title="Last updated on Aug 24, 2021, 6:18 AM UTC (07f1def)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/991/1eb7e8c...07f1def.html" title="Last updated on Aug 24, 2021, 6:18 AM UTC (07f1def)">Diff</a>