### PR TITLE
Editorial: switch completely to infra types

### DIFF
--- a/index.html
+++ b/index.html
@@ -1062,7 +1062,7 @@
             value=] passing |response|'s [=response/body=].
             </li>
             <li>If the |json| is a parsing exception, or |json| is not
-            [=ordered map=]:
+            an [=ordered map=]:
               <ol>
                 <li>Set |json:ordered map| to an empty [=ordered map=].
                 </li>

--- a/index.html
+++ b/index.html
@@ -1265,20 +1265,21 @@
           purpose</a>.
         </p>
         <p class="note">
-          For example, an icon with purpose "<a>monochrome</a>" could be used
-          as a badge or pinned icon with a solid fill, visually distinct from
-          an application's full color launch icon. The user agent uses the
-          value of the [=manifest image resource/purpose=] member as a hint to
-          determine where and how an [=manifest image resource/purpose=] is
-          displayed. Unless declared otherwise by the developer, a user agent
-          can use an icon for [=any|any purpose=].
+          For example, an icon with purpose "[=icon purpose/monochrome=]" could
+          be used as a badge or pinned icon with a solid fill, visually
+          distinct from an application's full color launch icon. The user agent
+          uses the value of the [=manifest image resource/purpose=] member as a
+          hint to determine where and how an [=manifest image
+          resource/purpose=] is displayed. Unless declared otherwise by the
+          developer, a user agent can use an icon for [=icon purpose/any|any
+          purpose=].
         </p>
         <p>
           The <dfn>icon purposes</dfn> are as follows:
         </p>
         <dl>
           <dt>
-            "<dfn>monochrome</dfn>"
+            <dfn data-dfn-for="icon purpose">monochrome</dfn>
           </dt>
           <dd>
             <aside class="issue atrisk" data-number="905"></aside>
@@ -1291,7 +1292,7 @@
             user agent like a mask over any solid fill.
           </dd>
           <dt>
-            "<dfn>maskable</dfn>"
+            <dfn data-dfn-for="icon purpose">maskable</dfn>
           </dt>
           <dd>
             The image is designed with <a href="#icon-masks">icon masks and
@@ -1300,12 +1301,17 @@
             by the user agent.
           </dd>
           <dt>
-            "<dfn>any</dfn>" (default)
+            <dfn data-dfn-for="icon purpose">any</dfn> (default)
           </dt>
           <dd>
             The user agent is free to display the icon in any context.
           </dd>
         </dl>
+        <p>
+          The <dfn>icon purposes list</dfn> is the [=list=] « "[=icon
+          purpose/monochrome=]", "[=icon purpose/maskable=]", "[=icon
+          purpose/any=]" ».
+        </p>
         <p class="note">
           If an icon contains multiple purposes, it could be used for any of
           those purposes. If none of the stated purposes are recognized, the
@@ -1333,8 +1339,8 @@
           </li>
           <li>[=set/For each=] |keyword:string| of |keywords|:
             <ol>
-              <li>If |keyword| is not one of the [=icon purposes=], then
-              [=iteration/continue=].
+              <li>If [=icon purposes list=] doesn't [=list/contain=] |keyword|,
+              then [=iteration/continue=].
               </li>
               <li>Otherwise, [=set/append=] |keyword| to |purposes|.
               </li>
@@ -1401,22 +1407,22 @@
           Some platforms have their own preferred icon shape, but as web
           applications should work across multiple platforms, it is possible to
           indicate that an icon can have a user-agent-specified mask applied by
-          adding the <a>maskable</a> purpose. This allows the platform to
-          ensure that the icon looks well integrated with the platform, and
-          even apply different masks and background colors in different places
-          throughout the platform.
+          adding the [=icon purpose/maskable=] purpose. This allows the
+          platform to ensure that the icon looks well integrated with the
+          platform, and even apply different masks and background colors in
+          different places throughout the platform.
         </p>
         <p>
-          The <dfn>safe zone</dfn> is the area within a <a>maskable</a> icon
-          which is guaranteed to always be visible, regardless of user agent
-          preferences. It is defined as a circle with center point in the
-          center of the icon and with a radius of 2/5 (40%) of the icon size,
-          which means the smaller of the icon width and height, in case the
-          icon is not square.
+          The <dfn>safe zone</dfn> is the area within a [=icon
+          purpose/maskable=] icon which is guaranteed to always be visible,
+          regardless of user agent preferences. It is defined as a circle with
+          center point in the center of the icon and with a radius of 2/5 (40%)
+          of the icon size, which means the smaller of the icon width and
+          height, in case the icon is not square.
         </p>
         <p class="note">
-          Designers of <a>maskable</a> icons will want to make sure that all
-          important parts are within the <a>safe zone</a>.
+          Designers of [=icon purpose/maskable=] icons will want to make sure
+          that all important parts are within the <a>safe zone</a>.
         </p>
         <figure>
           <img src="images/safe-zone.svg" width="340" height="340" alt=
@@ -1539,22 +1545,23 @@
           icon can be declared in a [=manifest=]. As web applications need to
           work across multiple platforms, it is possible to indicate that an
           icon can have an user-agent-specified color applied by adding the
-          <a>monochrome</a> purpose. This allows the platform to ensure that
-          the icon looks well integrated with the platform, and even apply
-          different colors and padding in different places throughout the
-          platform.
+          [=icon purpose/monochrome=] purpose. This allows the platform to
+          ensure that the icon looks well integrated with the platform, and
+          even apply different colors and padding in different places
+          throughout the platform.
         </p>
         <p>
-          When presenting a <a>monochrome</a> icon, the user agent MUST NOT
-          independently display the red component, green component, or blue
-          component of a pixel. The user agent SHOULD display each pixel with
-          its original alpha value, but with a red, green, and blue value of
-          the user agent's choosing. It is RECOMMENDED that the user agent use
-          the same color value for all pixels.
+          When presenting a [=icon purpose/monochrome=] icon, the user agent
+          MUST NOT independently display the red component, green component, or
+          blue component of a pixel. The user agent SHOULD display each pixel
+          with its original alpha value, but with a red, green, and blue value
+          of the user agent's choosing. It is RECOMMENDED that the user agent
+          use the same color value for all pixels.
         </p>
         <p class="note">
-          Designers of <a>monochrome</a> icons could set all pixels to black
-          and only use transparency to create a silhouette of their icon.
+          Designers of [=icon purpose/monochrome=] icons could set all pixels
+          to black and only use transparency to create a silhouette of their
+          icon.
         </p>
         <p>
           The user agent MAY enlarge the icon by adding additional padding.

--- a/index.html
+++ b/index.html
@@ -1061,8 +1061,8 @@
             <li>Let |json| be the result of [=parse JSON bytes to an Infra
             value=] passing |response|'s [=response/body=].
             </li>
-            <li>If the |json| is a parsing exception, or |json| is not
-            an [=ordered map=]:
+            <li>If the |json| is a parsing exception, or |json| is not an
+            [=ordered map=]:
               <ol>
                 <li>Set |json:ordered map| to an empty [=ordered map=].
                 </li>

--- a/index.html
+++ b/index.html
@@ -725,14 +725,14 @@
           [[SCREEN-ORIENTATION]] API).
         </p>
         <p>
-          To <dfn>process the `orientation` member</dfn>, given JSON
+          To <dfn>process the `orientation` member</dfn>, given [=ordered map=]
           |json:ordered map| and [=ordered map=] |manifest:ordered map|:
         </p>
         <ol class="algorithm">
           <li>If |json|["orientation"] doesn't [=map/exist=] or
           |json|["orientation"] is not a [=string=], return.
           </li>
-          <li>If |json|["orientation"] doesn't [=list/contain=] one of the
+          <li>If |json|["orientation"] doesn't [=list/contain=] any of the
           [=orientation values=], return.
           </li>
           <li>Set |manifest|["orientation"] to |json|["orientation"].
@@ -976,7 +976,8 @@
         </p>
         <p>
           To <dfn>process the `shortcuts` member</dfn>, given [=ordered map=]
-          |json:ordered map|, |manifest:ordered map|, and |manifest URL:URL|:
+          |json:ordered map|, [=ordered map=] |manifest:ordered map|, and
+          [=URL=] |manifest URL:URL|:
         </p>
         <ol class="algorithm">
           <li>Let |processedShortcuts:list| be a new [=list=].
@@ -1138,9 +1139,9 @@
             "@color-profile" rule which cannot be specified in the manifest.
           </p>
           <p>
-            To <dfn>process a color member</dfn>, using JSON |json:ordered
-            map|, [=ordered map=] |map:ordered map|, and [=string=]
-            |member:string|:
+            To <dfn>process a color member</dfn>, using [=ordered map=]
+            |json:ordered map|, [=ordered map=] |map:ordered map|, and
+            [=string=] |member:string|:
           </p>
           <ol class="algorithm">
             <li>If |json|[member] doesn't [=map/exist=] or |json|[member] is

--- a/index.html
+++ b/index.html
@@ -156,15 +156,6 @@
         application is launched.
       </p>
       <p>
-        As a manifest is JSON, this specification relies on the types defined
-        in [[JSON]] specification: namely <dfn data-no-export="">object</dfn>,
-        <dfn data-no-export="">array</dfn>, <dfn data-no-export=
-        "">string</dfn>, and <dfn data-no-export="">boolean</dfn>. Strict type
-        checking is not enforced by this specification. Instead, each member's
-        definition specifies the steps required to process a particular member
-        and what to do when a type does not match what is expected.
-      </p>
-      <p>
         A manifest has an associated <dfn>manifest URL</dfn>, which is the
         [[URL]] from which the <a>manifest</a> was fetched.
       </p>
@@ -435,8 +426,8 @@
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">dir</dfn></code> member specifies the <dfn>base
           direction</dfn> for the <a>localizable members</a> of the
-          <a>manifest</a>. The [=manifest/dir=] member's value can be set to
-          one of the <a>text-direction values</a>.
+          <a>manifest</a>. The [=manifest/dir=] member's value can be set to a
+          <a>text-direction</a>.
         </p>
         <p>
           The <dfn>localizable members</dfn> are:
@@ -454,52 +445,60 @@
           </li>
         </ul>
         <p>
-          The <dfn>text-direction values</dfn> are the following, implying that
-          the value of the <a>localizable members</a> is by default:
+          The <dfn>text-directions</dfn> are the following, implying that the
+          value of the <a>localizable members</a> is by default:
         </p>
         <dl>
           <dt>
-            "<dfn>ltr</dfn>"
+            "<dfn data-dfn-for="text-direction">ltr</dfn>"
           </dt>
           <dd>
             Left-to-right text.
           </dd>
           <dt>
-            "<dfn>rtl</dfn>"
+            "<dfn data-dfn-for="text-direction">rtl</dfn>"
           </dt>
           <dd>
             Right-to-left text.
           </dd>
           <dt>
-            "<dfn>auto</dfn>" (default)
+            "<dfn data-dfn-for="text-direction">auto</dfn>" (default)
           </dt>
           <dd>
             No explicit directionality.
           </dd>
         </dl>
         <p>
+          The <dfn>text-direction list</dfn> is the [=list=] «
+          "[=text-direction/ltr=]", "[=text-direction/rtl=]",
+          "[=text-direction/auto=]" ».
+        </p>
+        <p>
           When displaying the <a>localizable members</a> to an end-user, the
           use agent SHOULD:
         </p>
         <ol class="algorithm">
-          <li>If the <a>base direction</a> is <a>ltr</a> or <a>rtl</a>,
-          override <a data-cite="bidi#P3">Rule P3</a> of [[BIDI]], setting the
-          paragraph embedding level to 0 if the <a>base direction</a> is
-          <a>ltr</a>, or 1 if the <a>base direction</a> is <a>rtl</a>.
+          <li>If the <a>base direction</a> is [=text-direction/ltr=] or
+          [=text-direction/rtl=], override <a data-cite="bidi#P3">Rule P3</a>
+          of [[BIDI]], setting the paragraph embedding level to 0 if the
+          <a>base direction</a> is [=text-direction/ltr=], or 1 if the <a>base
+          direction</a> is [=text-direction/rtl=].
           </li>
-          <li>Otherwise the <a>base direction</a> is "[=auto=]", in which case
-          determine the text's direction by applying <a data-cite=
-          "bidi#P1">Rule P1</a> of [[BIDI]].
+          <li>Otherwise the <a>base direction</a> is "[=text-direction/auto=]",
+          in which case determine the text's direction by applying
+            <a data-cite="bidi#P1">Rule P1</a> of [[BIDI]].
           </li>
         </ol>
         <p>
-          To <dfn>process the `dir` member</dfn>, given [=object=] |json:JSON|
-          and [=ordered map=] |manifest:ordered map|:
+          To <dfn>process the `dir` member</dfn>, given [=ordered map=]
+          |json:ordered map| and [=ordered map=] |manifest:ordered map|:
         </p>
         <ol class="algorithm">
-          <li>If the type of |json|["dir"] is not [=string=], or if
-          |json|["dir"] doesn't match one of the [=text-direction values=],
-          return.
+          <li>If |json|["dir"] doesn't [=map/exist=] or if |json|["dir"] is not
+          a [=string=], return.
+          </li>
+          <li>If [=text-direction list=] doesn't [=list/contain=]
+          |json|["dir"], return.
           </li>
           <li>Set |manifest|["dir"] to |json|["dir"].
           </li>
@@ -531,11 +530,12 @@
           Language Subtag Registry are considered structurally valid.
         </p>
         <p>
-          To <dfn>process the `lang` member</dfn>, given [=object=] |json:JSON|
-          and [=ordered map=] |manifest:ordered map|:
+          To <dfn>process the `lang` member</dfn>, given [=ordered map=]
+          |json:ordered map| and [=ordered map=] |manifest:ordered map|:
         </p>
         <ol class="algorithm">
-          <li>If the type of |json|["lang"] is not [=string=], return.
+          <li>If |json|["lang"] doesn't [=map/exist=] or if |json|["lang"] is
+          not a [=string=], return.
           </li>
           <li>If calling <a data-cite=
           "ECMA-402#sec-isstructurallyvalidlanguagetag">IsStructurallyValidLanguageTag</a>
@@ -602,8 +602,8 @@
           </p>
         </aside>
         <p>
-          To <dfn>process the `scope` member</dfn>, given [=object=]
-          |json:JSON| and [=ordered map=] |manifest:ordered map|:
+          To <dfn>process the `scope` member</dfn>, given [=ordered map=]
+          |json:ordered map| and [=ordered map=] |manifest:ordered map|:
         </p>
         <ol class="algorithm">
           <li>Set |manifest|["scope"] to the result of [=URL Parser|parsing=]
@@ -663,18 +663,19 @@
         <p>
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">display</dfn></code> member represents the developer's
-          preferred <a>display mode</a> for the web application. Its value is
-          one of the <a>display modes values</a>.
+          preferred <a>display mode</a> for the web application. Its value is a
+          [=display mode=].
         </p>
         <p>
-          To <dfn>process the `display` member</dfn>, given [=object=]
-          |json:JSON| and [=ordered map=] |manifest:ordered map|:
+          To <dfn>process the `display` member</dfn>, given [=ordered map=]
+          |json:ordered map| and [=ordered map=] |manifest:ordered map|:
         </p>
         <ol class="algorithm">
-          <li>If the type of |json|["display"] is not [=string=], return.
+          <li>If |json|["display"] doesn't [=map/exist=] or |json|["display"]
+          is not a a [=string=], return.
           </li>
-          <li>If |json|["display"] doesn't match one of the [=display modes
-          values=], return.
+          <li>If [=display modes list=] doesn't [=list/contain=]
+          |json|["display"], return.
           </li>
           <li>Set |manifest|["display"] to |json|["display"].
           </li>
@@ -712,12 +713,12 @@
         </p>
         <p>
           Certain UI/UX concerns and/or platform conventions will mean that
-          some screen orientations and display modes <dfn>cannot be used
-          together</dfn>. Which orientations and display modes cannot be used
-          together is left to the discretion of implementers. For example, for
-          some user agents, it might not make sense to change the <a>default
-          screen orientation</a> of an application while in `browser`
-          <a>display mode</a>.
+          some screen orientations and <dfn>cannot be used together</dfn>.
+          Which orientations and display modes cannot be used together is left
+          to the discretion of implementers. For example, for some user agents,
+          it might not make sense to change the <a>default screen
+          orientation</a> of an application while in `browser` <a>display
+          mode</a>.
         </p>
         <p class="note">
           Once the web application is running, other means can change the
@@ -726,13 +727,14 @@
         </p>
         <p>
           To <dfn>process the `orientation` member</dfn>, given JSON
-          |json:JSON| and [=ordered map=] |manifest:ordered map|:
+          |json:ordered map| and [=ordered map=] |manifest:ordered map|:
         </p>
         <ol class="algorithm">
-          <li>If the type of |json|["orientation"] is not [=string=], return.
+          <li>If |json|["orientation"] doesn't [=map/exist=] or
+          |json|["orientation"] is not a [=string=], return.
           </li>
-          <li>If |json|["orientation"] doesn't match one of the [=orientation
-          values=], return.
+          <li>If |json|["orientation"] doesn't [=list/contain=] one of the
+          [=orientation values=], return.
           </li>
           <li>Set |manifest|["orientation"] to |json|["orientation"].
           </li>
@@ -758,12 +760,13 @@
           being created or any time thereafter.
         </p>
         <p>
-          To <dfn>process the `start_url` member</dfn>, given [=object=]
-          |json:JSON|, [=ordered map=] |manifest:ordered map|, [=URL=]
+          To <dfn>process the `start_url` member</dfn>, given [=ordered map=]
+          |json:ordered map|, [=ordered map=] |manifest:ordered map|, [=URL=]
           |manifest URL:URL|, and [=URL=] |document URL:URL|:
         </p>
         <ol class="algorithm">
-          <li>If the type of |json|["start_url"] is not [=string=], return.
+          <li>If |json|["start_url"] doesn't [=map/exist=] or
+          |json|["start_url"] is not a [=string=], return.
           </li>
           <li>If |json|["start_url"] is the empty string, return.
           </li>
@@ -869,15 +872,16 @@
         </p>
         <p>
           To <dfn>process the `related_applications` member</dfn>, given
-          [=object=] |json:JSON| and [=ordered map=] |manifest:ordered map|:
+          [=ordered map=] |json:ordered map| and [=ordered map=]
+          |manifest:ordered map|:
         </p>
         <ol class="algorithm">
           <li>Let |relatedApplications:list| be a new [=list=].
           </li>
           <li>Set |manifest|["related_applications"] to |relatedApplications|.
           </li>
-          <li>If the type of |json|["related_applications"] is not [=array=],
-          return.
+          <li>If |json|["related_applications"] doesn't [=map/exist=] or
+          |json|["related_applications"] is not a [=list=], return.
           </li>
           <li>[=list/For each=] <var>app</var> of
           |json|["related_applications"]:
@@ -952,7 +956,7 @@
         </h3>
         <p>
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
-          "manifest">shortcuts</dfn></code> member is an [=array=] of
+          "manifest">shortcuts</dfn></code> member is an [=list=] of
           <a>shortcut item</a>s that provide access to key tasks within a web
           application.
         </p>
@@ -964,7 +968,7 @@
           </p>
           <p>
             Developers are encouraged to order their shortcuts by priority,
-            with the most critical shortcuts appearing first in the array.
+            with the most critical shortcuts appearing first in the list.
           </p>
         </aside>
         <p>
@@ -972,19 +976,20 @@
           user, is at the discretion of the user agent and/or operating system.
         </p>
         <p>
-          To <dfn>process the `shortcuts` member</dfn>, given [=object=]
-          |json:JSON|, |manifest:ordered map|, and |manifest URL:URL|:
+          To <dfn>process the `shortcuts` member</dfn>, given [=ordered map=]
+          |json:ordered map|, |manifest:ordered map|, and |manifest URL:URL|:
         </p>
         <ol class="algorithm">
           <li>Let |processedShortcuts:list| be a new [=list=].
           </li>
           <li>Set |manifest|["shortcuts"] to |processedShortcuts|.
           </li>
-          <li>If the type of |json|["shortcuts"] is not [=array=], return.
+          <li>If |json|["shortcuts"] doesn't [=map/exist=] or
+          |json|["shortcuts"] is not a [=list=], return.
           </li>
-          <li>[=list/For each=] |entry:object| of |json|["shortcuts"]:
+          <li>[=list/For each=] |entry:ordered map| of |json|["shortcuts"]:
             <ol>
-              <li>Let |shortcut:Ordered map| be [=process a shortcut=] with
+              <li>Let |shortcut:ordered map| be [=process a shortcut=] with
               |entry|.
               </li>
               <li>If |shortcut| is failure, continue.
@@ -1053,19 +1058,19 @@
             </li>
             <li>Assert: |document URL:URL| is not null.
             </li>
-            <li>Let |json| be the result of [=parse JSON from bytes=]
-            |response|'s [=response/body=].
+            <li>Let |json| be the result of [=parse JSON bytes to an Infra
+            value=] passing |response|'s [=response/body=].
             </li>
-            <li>If the |json| is a parsing exception, or the type of |json| is
-            not [=object=]:
+            <li>If the |json| is a parsing exception, or |json| is not
+            [=ordered map=]:
               <ol>
-                <li>Set |json:object| to an empty [=object=] (i.e., equivalent
-                of JSON parsing the string `"{}"`).
+                <li>Set |json:ordered map| to an empty [=ordered map=].
                 </li>
               </ol>
             </li>
-            <li>Let |manifest| be a new [=ordered map=] «[ "display" →
-            "browser", "dir" → "auto", "start_url" → |document URL| ]».
+            <li>Let |manifest:ordered map| be a new [=ordered map=] «[
+            "display" → "browser", "dir" → "auto", "start_url" → |document URL|
+            ]».
             </li>
             <li>[=Process the `dir` member=] passing |json| and |manifest|.
             </li>
@@ -1081,6 +1086,8 @@
             </li>
             <li>[=Process a text member=] passing |json|, |manifest|, and
             "short_name".
+            </li>
+            <li>Let |manifest URL:URL| be |response|'s [=response/URL=].
             </li>
             <li>[=Process the `start_url` member=] passing |json|, |manifest|,
             |manifest URL|, and |document URL|.
@@ -1132,11 +1139,13 @@
             "@color-profile" rule which cannot be specified in the manifest.
           </p>
           <p>
-            To <dfn>process a color member</dfn>, using JSON |json:JSON|,
-            [=ordered map=] |map:ordered map|, and [=string=] |member:string|:
+            To <dfn>process a color member</dfn>, using JSON |json:ordered
+            map|, [=ordered map=] |map:ordered map|, and [=string=]
+            |member:string|:
           </p>
           <ol class="algorithm">
-            <li>If the type of |json|[member] is not [=string=], return.
+            <li>If |json|[member] doesn't [=map/exist=] or |json|[member] is
+            not a [=string=], return.
             </li>
             <li>Let |color| be the result of [=CSS/parsing=] the value of
             |json|[member] as a CSS color.
@@ -1158,11 +1167,13 @@
             Processing text members
           </h2>
           <p>
-            To <dfn>process a text member</dfn>, given [=object=] |json:JSON|,
-            [=ordered map=] |map:ordered map|, and [=string=] |member:string|:
+            To <dfn>process a text member</dfn>, given [=ordered map=]
+            |json:ordered map|, [=ordered map=] |map:ordered map|, and
+            [=string=] |member:string|:
           </p>
           <ol class="algorithm">
-            <li>If the type of |json|[|member|] is not [=string=], return.
+            <li>If |json|[|member|] doesn't [=map/exists=] or |json|[|member|]
+            is not a [=string=], return.
             </li>
             <li>Set |map|[member] to the value of |json|[|member|].
             </li>
@@ -1304,11 +1315,12 @@
           the purpose `"fizzbuzz"`, then it will be ignored.
         </p>
         <p>
-          To <dfn>determine the purpose of an image</dfn>, given [=object=]
-          |json:image|:
+          To <dfn>determine the purpose of an image</dfn>, given [=ordered
+          map=] |json:image|:
         </p>
         <ol class="algorithm">
-          <li>If the type of |json|["purpose"] is not [=string=]:
+          <li>If |json|["purpose"] doesn't [=map/exist=] or if
+          |json|["purpose"] is not a [=string=]:
             <ol>
               <li>Return [=set=] « "any" ».
               </li>
@@ -1592,9 +1604,9 @@
           Processing image resources
         </h3>
         <p>
-          To <dfn>process image resources</dfn>, given [=array=]
-          |images:array|, [=ordered map=] |map:ordered map|, |manifest URL:URL|
-          and [=string=] |member:string|:
+          To <dfn>process image resources</dfn>, given [=list=] |images:list|,
+          [=ordered map=] |map:ordered map|, |manifest URL:URL| and [=string=]
+          |member:string|:
         </p>
         <ol class="algorithm">
           <li>Let |imageResources:List&lt;Image&nbsp;Resources&gt;| be a new
@@ -1602,7 +1614,7 @@
           </li>
           <li>Set |map|[member] to |imageResources|.
           </li>
-          <li>If the type of |images| is not [=array=], return.
+          <li>If |images| is not [=list=], return.
           </li>
           <li>[=list/For each=] |potential image:Manifest image resource| of
           |images|:
@@ -1633,8 +1645,8 @@
       </h2>
       <p>
         Each <dfn data-local-lt="Shortcut item's">shortcut item</dfn> is an
-        [=object=] that represents a link to a key task or page within a web
-        app. It has the following members:
+        [=ordered map=] that represents a link to a key task or page within a
+        web app. It has the following members:
       </p>
       <ul>
         <li>[=shortcut item/name=]
@@ -1733,15 +1745,23 @@
           Processing shortcut items
         </h2>
         <p>
-          To <dfn>process a shortcut</dfn>, given [=object=] |item:object|:
+          To <dfn>process a shortcut</dfn>, given [=ordered map=] |item:ordered
+          map|:
         </p>
         <ol class="algorithm">
-          <li>If the type of |item| is not [=object=], return failure.
-          </li>
-          <li>If |item|["name"] is missing or |item|["name"] is the empty
-          string, return failure.
-          </li>
-          <li>If the type of |item|["url"] is not [=string=], return failure.
+          <li>Return failure if it's the case that:
+            <ul>
+              <li>|item| is not [=ordered map=].
+              </li>
+              <li>|item|["name"] doesn't [=map/exist=].
+              </li>
+              <li>|item|["name"] is the empty string.
+              </li>
+              <li>|item|["url"] doesn't [=map/exist=].
+              </li>
+              <li>|item|["url"] is not a [=string=].
+              </li>
+            </ul>
           </li>
           <li>Let |url:URL| be the result of [=URL Parser|parsing=]
           |item|["url"] with |manifest URL| as the base URL.
@@ -1895,7 +1915,7 @@
         <p>
           An [=external application resource's=] <code><dfn data-dfn-for=
           "external application resource">fingerprints</dfn></code> member
-          represents an array of [=fingerprints=].
+          represents an [=list=] of [=fingerprints=].
         </p>
         <p>
           A <dfn data-local-lt="fingerprints">fingerprint</dfn> represents a
@@ -2169,6 +2189,58 @@
         interpret them how they best see fit.
       </p>
       <p>
+        This specification defines the following [=display modes=]:
+      </p>
+      <dl>
+        <dt>
+          <dfn data-dfn-for="display mode">fullscreen</dfn>
+        </dt>
+        <dd>
+          Opens the web application with browser UI elements hidden and takes
+          up the entirety of the available display area.
+        </dd>
+        <dt>
+          <dfn data-dfn-for="display mode">standalone</dfn>
+        </dt>
+        <dd>
+          Opens the web application to look and feel like a standalone native
+          application. This can include the application having a different
+          window, its own icon in the application launcher, etc. In this mode,
+          the user agent will exclude standard browser UI elements such as an
+          URL bar, but can include other system UI elements such as a status
+          bar and/or system back button.
+        </dd>
+        <dt>
+          <dfn data-dfn-for="display mode">minimal-ui</dfn>
+        </dt>
+        <dd>
+          This mode is similar to [=display mode/standalone=], but provides the
+          end-user with some means to access a minimal set of UI elements for
+          controlling navigation (i.e., back, forward, reload, and perhaps some
+          way of viewing the document's address). A user agent can include
+          other platform specific UI elements, such as "share" and "print"
+          buttons or whatever is customary on the platform and user agent.
+        </dd>
+        <dt>
+          <dfn data-dfn-for="display mode">browser</dfn> (default)
+        </dt>
+        <dd>
+          Opens the web application using the platform-specific convention for
+          opening hyperlinks in the user agent (e.g., in a browser tab or a new
+          window).
+        </dd>
+      </dl>
+      <p class="note">
+        The [=display mode/fullscreen=] <a>display mode</a> is orthogonal to,
+        and works independently of, the [[[FULLSCREEN]]]. The [=display
+        mode/fullscreen=] <a>display mode</a> affects the fullscreen state of
+        the browser window, while the [[FULLSCREEN]] API operates on an element
+        contained within the viewport. As such, a web application can have its
+        <a>display mode</a> set to [=display mode/fullscreen=], while
+        `document.fullScreenElement` returns `null`, and `fullscreenEnabled`
+        returns `false`.
+      </p>
+      <p>
         Once a user agent [=applies=] a particular <a>display mode</a> to an
         <a>application context</a>, it becomes the <dfn>default display
         mode</dfn> for the <a>top-level browsing context</a> (i.e., it is used
@@ -2180,24 +2252,25 @@
       </p>
       <p>
         When the [=manifest/display=] member is missing, or if there is no
-        valid [=manifest/display=] member, the user agent uses the
-        <a>browser</a> <a>display mode</a> as the <a>default display mode</a>.
-        As such, the user agent MUST support the <a>browser</a> <a>display
-        mode</a>.
+        valid [=manifest/display=] member, the user agent uses the [=display
+        mode/browser=] <a>display mode</a> as the <a>default display mode</a>.
+        As such, the user agent MUST support the [=display mode/browser=]
+        <a>display mode</a>.
       </p>
       <p>
         Every [=display mode=] has a <dfn>fallback chain</dfn>, which is a list
         of [=display modes=]. The [=fallback chain=] for:
       </p>
       <ol>
-        <li>[=browser=] is «».
+        <li>[=display mode/browser=] is «».
         </li>
-        <li>[=minimal-ui=] is « "[=browser=]" ».
+        <li>[=display mode/minimal-ui=] is « "[=display mode/browser=]" ».
         </li>
-        <li>[=standalone=] is « "[=minimal-ui=]", "[=browser=]" ».
+        <li>[=display mode/standalone=] is « "[=display mode/minimal-ui=]",
+        "[=display mode/browser=]" ».
         </li>
-        <li>[=fullscreen=] is « "[=standalone=]", "[=minimal-ui=]",
-        "[=browser=]" ».
+        <li>[=display mode/fullscreen=] is « "[=display mode/standalone=]",
+        "[=display mode/minimal-ui=]", "[=display mode/browser=]" ».
         </li>
       </ol>
       <p>
@@ -2225,9 +2298,9 @@
       </ol>
       <p class="note">
         The above loop is guaranteed to return a value before the assertion,
-        due to the fact that {{browser}} is in every mode's [=fallback chain=],
-        and the requirement that all user agents support the {{browser}}
-        [=display mode=].
+        due to the fact that [=display mode/browser=] is in every mode's
+        [=fallback chain=], and the requirement that all user agents support
+        the [=display mode/browser=] [=display mode=].
       </p>
       <aside class="example">
         <p>
@@ -2241,55 +2314,9 @@
         </p>
       </aside>
       <p>
-        The <dfn>display modes values</dfn> are:
-      </p>
-      <dl>
-        <dt>
-          "<dfn>fullscreen</dfn>"
-        </dt>
-        <dd>
-          Opens the web application with browser UI elements hidden and takes
-          up the entirety of the available display area.
-        </dd>
-        <dt>
-          "<dfn>standalone</dfn>"
-        </dt>
-        <dd>
-          Opens the web application to look and feel like a standalone native
-          application. This can include the application having a different
-          window, its own icon in the application launcher, etc. In this mode,
-          the user agent will exclude standard browser UI elements such as an
-          URL bar, but can include other system UI elements such as a status
-          bar and/or system back button.
-        </dd>
-        <dt>
-          "<dfn>minimal-ui</dfn>"
-        </dt>
-        <dd>
-          This mode is similar to <a>standalone</a>, but provides the end-user
-          with some means to access a minimal set of UI elements for
-          controlling navigation (i.e., back, forward, reload, and perhaps some
-          way of viewing the document's address). A user agent can include
-          other platform specific UI elements, such as "share" and "print"
-          buttons or whatever is customary on the platform and user agent.
-        </dd>
-        <dt>
-          "<dfn>browser</dfn>" (default)
-        </dt>
-        <dd>
-          Opens the web application using the platform-specific convention for
-          opening hyperlinks in the user agent (e.g., in a browser tab or a new
-          window).
-        </dd>
-      </dl>
-      <p class="note">
-        The <a>fullscreen</a> <a>display mode</a> is orthogonal to, and works
-        independently of, the [[[FULLSCREEN]]]. The <a>fullscreen</a>
-        <a>display mode</a> affects the fullscreen state of the browser window,
-        while the [[FULLSCREEN]] API operates on an element contained within
-        the viewport. As such, a web application can have its <a>display
-        mode</a> set to <a>fullscreen</a>, while `document.fullScreenElement`
-        returns `null`, and `fullscreenEnabled` returns `false`.
+        The <dfn>display modes list</dfn> is the [=list=] « "[=display
+        mode/fullscreen=]", "[=display mode/standalone=]", "[=display
+        mode/minimal-ui=]", "[=display mode/browser=]" ».
       </p>
       <section data-cite="css-conditional-3">
         <h3>
@@ -2319,8 +2346,8 @@
                 Value:
               </th>
               <td class="prod">
-                <a>fullscreen</a> | <a>standalone</a> | <a>minimal-ui</a> |
-                <a>browser</a>
+                [=display mode/fullscreen=] | [=display mode/standalone=] |
+                [=display mode/minimal-ui=] | [=display mode/browser=]
               </td>
             </tr>
             <tr>
@@ -2510,13 +2537,13 @@
       </p>
       <p>
         Additionally, when applying a manifest that sets the <a>display
-        mode</a> to anything except "<a>browser</a>", it is RECOMMENDED that
-        the user agent clearly indicate to the end-user that their are leaving
-        the normal browsing context of a web browser. Ideally, launching or
-        switching to a web application is performed in a manner that is
-        consistent with launching or switching to other applications in the
-        host platform. For example, a long and obvious animated transition, or
-        speaking the text "Launching application X".
+        mode</a> to anything except "[=display mode/browser=]", it is
+        RECOMMENDED that the user agent clearly indicate to the end-user that
+        their are leaving the normal browsing context of a web browser.
+        Ideally, launching or switching to a web application is performed in a
+        manner that is consistent with launching or switching to other
+        applications in the host platform. For example, a long and obvious
+        animated transition, or speaking the text "Launching application X".
       </p>
       <p>
         The `'display-mode'` media feature allows an origin access to aspects


### PR DESCRIPTION
Closes #984 

CC @phoglenix

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

Entirely removes reliance on JS object types, and now solely uses Infra types throughout.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/992.html" title="Last updated on Aug 11, 2021, 7:14 AM UTC (4557146)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/992/0e886d1...4557146.html" title="Last updated on Aug 11, 2021, 7:14 AM UTC (4557146)">Diff</a>