### PR TITLE
Editorial: monochrome no longer at risk

### DIFF
--- a/index.html
+++ b/index.html
@@ -1282,9 +1282,6 @@
             <dfn data-dfn-for="icon purpose">monochrome</dfn>
           </dt>
           <dd>
-            <aside class="issue atrisk" data-number="905"></aside>
-          </dd>
-          <dd>
             A user agent can present this icon where a <a href=
             "#monochrome-icons-and-solid-fills">monochrome icon with a solid
             fill</a> is needed. The color information in the icon is discarded


### PR DESCRIPTION
Closes #905 

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Implementation commitment (delete if not making normative changes):

* [ ] WebKit (https://bugs.webkit.org)
* [X] Chromium - https://bugs.chromium.org/p/chromium/issues/detail?id=1114638
* [X] Gecko

Commit message:

No longer "at risk". 
