### PR TITLE
use url equivalence excluding fragments for id comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -831,11 +831,12 @@
           application, it SHOULD treat that manifest as a description of a
           distinct application, even if it is served from the same URL as that
           of another application. When the user agent sees a manifest where
-          |manifest|["id"] [=url/equal|equals=] the [=identity=] of an
-          already-installed application, it SHOULD be used as a signal that
-          this manifest is a replacement for the already-installed
-          application's manifest, and not a distinct application, even if it is
-          served from a different URL than the one seen previously.
+          |manifest|["id"] [=URL serializer/exclude fragment|excluding
+          fragments=] [=url/equal|equals=] the [=identity=] of an
+          already-installed application, it SHOULD be used as a signal that this
+          manifest is a replacement for the already-installed application's
+          manifest, and not a distinct application, even if it is served from a
+          different URL than the one seen previously.
         </p>
         <p class="note">
           The [=identity=] can be used by a service that collects lists of web
@@ -896,17 +897,6 @@
               </td>
               <td>
                 "https://example.com/my-app/start"
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <i>undefined</i>
-              </td>
-              <td>
-                "https://example.com/my-app/#here"
-              </td>
-              <td>
-                "https://example.com/my-app/#here"
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
The https://url.spec.whatwg.org/#url-equivalence defaults to exclude fragments = false. Clarify in `id` member that the equality comparison here excludes fragments.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/philloooo/manifest/pull/1013.html" title="Last updated on Oct 11, 2021, 7:54 PM UTC (804f2c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1013/8d81603...philloooo:804f2c1.html" title="Last updated on Oct 11, 2021, 7:54 PM UTC (804f2c1)">Diff</a>