### PR TITLE
Link to manifest-app-info in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ the [Web Applications Working Group](https://www.w3.org/2019/webapps/).
 ## Useful links
 * [Explainer](https://github.com/w3c/manifest/blob/gh-pages/explainer.md)
 * [The Web App Manifest specification](https://www.w3.org/TR/appmanifest/)
+* [App Information supplement](https://github.com/w3c/manifest-app-info)
 * [Use cases and requirements](https://w3c-webmob.github.io/installable-webapps/)
 * [The Web Applications WG homepage](https://www.w3.org/2019/webapps/)


### PR DESCRIPTION
Closes #1027

This change (choose at least one, delete ones that don't apply):

* Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

chore: link to manifest-app-info in the README

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change
