### PR TITLE
Add scope conflict section about same-origin and nested scopes

### DIFF
--- a/index.html
+++ b/index.html
@@ -2501,8 +2501,11 @@
           (detailed below) and is thus considered bad practice.
         </p>
         <p>
-          Same-origin scopes are not recommended due to origin-based settings
-          that will affect all apps installed under that origin. Settings like:
+          One origin per application is ideal because it isolates common user
+          agent settings and controls to apply to only one web applications.
+          Without this isolation, these settings or controls can apply to more
+          than one web application, which will likely be unexpected by the
+          user. Examples:
         </p>
         <ul>
           <li>Permissions
@@ -2533,8 +2536,8 @@
           </li>
           <li>Notifications and notification attribution.
           </li>
-          <li>And current or future APIs that somehow correspond to a single web app identity
-          (e.g. badging).
+          <li>And current or future APIs that somehow correspond to a single
+          web app identity (e.g. badging).
           </li>
         </ul>
         <aside class="example">

--- a/index.html
+++ b/index.html
@@ -2467,8 +2467,7 @@
           </li>
         </ul>
         <p>
-          Nested scopes are strongly not recommended. They have the above
-          complications of same-origin scope, along with the following UX and
+          Further, overlapping, nested, or duplicate scopes can have the following UX and
           API problems or inconsistencies among other possible consistencies:
         </p>
         <ul>

--- a/index.html
+++ b/index.html
@@ -2434,6 +2434,59 @@
           </p>
         </aside>
       </section>
+      <section class="informative">
+        <h3>
+          Web Apps with scope conflicts
+        </h3>
+        <p>
+          It is possible for two web apps to be installed where there are
+          conflicts between the scope. These conflicts come with disadvantages
+          outlined below and they are generally not recommended.
+        </p>
+        <ul>
+          <li>The scopes of the two web apps can be on the same origin. Not
+          recommended.
+          </li>
+          <li>The scope of one web app can be nested inside the scope of the
+          other. Strongly not recommended.
+          </li>
+          <li>The scopes of the two web apps can be the same. Strongly not
+          recommended.
+          </li>
+        </ul>
+        <p>
+          Same-origin scopes are not recommended due to origin-based settings
+          that will affect all apps installed under that origin. Settings like:
+        </p>
+        <ul>
+          <li>Permissions
+          </li>
+          <li>Storage and storage quota
+          </li>
+          <li>User settings (e.g. font size)
+          </li>
+        </ul>
+        <p>
+          Nested scopes are strongly not recommended. They have the above
+          complications of same-origin scope, along with the following UX and
+          API problems or inconsistencies among other possible consistencies:
+        </p>
+        <ul>
+          <li>Installation prompting may not work for the nested app if the
+          outer app is installed.
+          </li>
+          <li>User-agent UX around launching an app for a browsing context may
+          be inconsistent or not appear.
+          </li>
+          <li>Badging API calls will not be able to consistently update the
+          correct web app badge.
+          </li>
+          <li>Notifications may have incorrect attribution or not appear.
+          </li>
+          <li>Future APIs may not work at all in this configuration.
+          </li>
+        </ul>
+      </section>
     </section>
     <section>
       <h2>

--- a/index.html
+++ b/index.html
@@ -2495,21 +2495,11 @@
           Web Apps with scope conflicts
         </h3>
         <p>
-          Because scopes are based on URL matching, it is possible for a developer to create
-          multiple web applications with the same, overlapping, or nested scopes. Doing so creates
-          several issues (detailed below) and is thus considered bad practice.
+          Because scopes are based on URL matching, it is possible for a
+          developer to create multiple web applications with the same,
+          overlapping, or nested scopes. Doing so creates several issues
+          (detailed below) and is thus considered bad practice.
         </p>
-        <ul>
-          <li>The scopes of the two web apps can be on the same origin. Not
-          recommended.
-          </li>
-          <li>The scope of one web app can be nested inside the scope of the
-          other. Strongly not recommended.
-          </li>
-          <li>The scopes of the two web apps can be the same. Strongly not
-          recommended.
-          </li>
-        </ul>
         <p>
           Same-origin scopes are not recommended due to origin-based settings
           that will affect all apps installed under that origin. Settings like:
@@ -2519,28 +2509,49 @@
           </li>
           <li>Storage and storage quota
           </li>
-          <li>User settings (e.g. font size)
+          <li>User settings (e.g. font size, zoom level)
           </li>
         </ul>
         <p>
-          Further, overlapping, nested, or duplicate scopes can have the following UX and
-          API problems or inconsistencies among other possible consistencies:
+          To aide with disambiguation apps with scope conflicts, user agents
+          can determine the <dfn>controlling app</dfn> for a given document
+          URL, which is an [=installed web application=] with the longest
+          [=manifest/scope=] where the document url is [=manifest/within
+          scope=] of that application. If multiple apps fit this description
+          (in the case of matching scopes), then the user agent may choose
+          none, one, or all, depending on the scenario.
+        </p>
+        <p>
+          The following scenarios may require the user agent choosing a
+          [=controlling app=], not work, or be unpredictable with nested or
+          matching scopes:
         </p>
         <ul>
-          <li>Installation prompting may not work for the nested app if the
-          outer app is installed.
+          <li>Installation prompting.
           </li>
-          <li>User-agent UX around launching an app for a browsing context may
-          be inconsistent or not appear.
+          <li>User-agent UX around launching an app for a browsing context.
           </li>
-          <li>Badging API calls will not be able to consistently update the
-          correct web app badge.
+          <li>Notifications and notification attribution.
           </li>
-          <li>Notifications may have incorrect attribution or not appear.
-          </li>
-          <li>Future APIs may not work at all in this configuration.
+          <li>And current or future APIs that somehow correspond to a single web app identity
+          (e.g. badging).
           </li>
         </ul>
+        <aside class="example">
+          <p>
+            If a user agent supports the notifications API and there are two
+            apps installed with matching scopes, which app should be seen as
+            the author of that notification if it comes from within the scope
+            of both?
+          </p>
+          <p>
+            If two apps are nested and a notification is triggered within scope
+            of both, the notification will likely be attributed to the
+            [=controlling app=]. But what if the nested app is not installed,
+            and the outer app is? Is the developer expecting the notification
+            to be attributed to the outer app?
+          </p>
+        </aside>
       </section>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -2439,9 +2439,9 @@
           Web Apps with scope conflicts
         </h3>
         <p>
-          It is possible for two web apps to be installed where there are
-          conflicts between the scope. These conflicts come with disadvantages
-          outlined below and they are generally not recommended.
+          Because scopes are based on URL matching, it is possible for a developer to create
+          multiple web applications with the same, overlapping, or nested scopes. Doing so creates
+          several issues (detailed below) and is thus considered bad practice.
         </p>
         <ul>
           <li>The scopes of the two web apps can be on the same origin. Not


### PR DESCRIPTION
Closes #539

This change (choose at least one, delete ones that don't apply):

* Adds new normative recommendations or optional items

Implementation commitment (delete if not making normative changes):

* [ ] WebKit (https://bugs.webkit.org)
* [x] Chromium (https://bugs.chromium.org/)
* [ ] Gecko (http://bugzilla.mozilla.org)


Commit message:

Elaborate recommendations around scope conflicts like same-origin scopes, nested scopes, etc.

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 502 Bad Gateway :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 2, 2023, 12:15 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdmurph%2Fmanifest%2F76e211629d4e66082c926ccde42ed2fbdcad1175%2Findex.html%3FisPreview%3Dtrue)

```
<html>
<head><title>502 Bad Gateway</title></head>
<body>
<center><h1>502 Bad Gateway</h1></center>
<hr><center>cloudflare</center>
</body>
</html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/manifest%231034.)._
</details>
