### PR TITLE
editorial: Move the definition of display-mode back to APPMANIFEST.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2539,13 +2539,67 @@
     </section>
     <section>
       <h2>
-        Choosing a display mode
+        Display modes
       </h2>
       <p>
-        A [=display mode=], as defined in [[MEDIAQUERIES-5]], represents how
-        the web application is being presented within the context of an OS
-        (e.g., in fullscreen, etc.). Display modes correspond to user interface
-        (UI) metaphors and functionality in use on a given platform.
+        A <dfn>display mode</dfn> represents how the web application is being
+        presented within the context of an OS (e.g., in fullscreen, etc.).
+        Display modes correspond to user interface (UI) metaphors and
+        functionality in use on a given platform. The UI conventions of the
+        display modes are purely advisory and implementers are free to
+        interpret them how they best see fit.
+      </p>
+      <p>
+        This specification defines the following [=display modes=]:
+      </p>
+      <dl>
+        <dt>
+          <dfn data-dfn-for="display mode">fullscreen</dfn>
+        </dt>
+        <dd>
+          Opens the web application with browser UI elements hidden and takes
+          up the entirety of the available display area.
+        </dd>
+        <dt>
+          <dfn data-dfn-for="display mode">standalone</dfn>
+        </dt>
+        <dd>
+          Opens the web application to look and feel like a standalone native
+          application. This can include the application having a different
+          window, its own icon in the application launcher, etc. In this mode,
+          the user agent will exclude standard browser UI elements such as an
+          URL bar, but can include other system UI elements such as a status
+          bar and/or system back button.
+        </dd>
+        <dt>
+          <dfn data-dfn-for="display mode">minimal-ui</dfn>
+        </dt>
+        <dd>
+          This mode is similar to [=display mode/standalone=], but provides the
+          end-user with some means to access a minimal set of UI elements for
+          controlling navigation (i.e., back, forward, reload, and perhaps some
+          way of viewing the document's address). A user agent can include
+          other platform specific UI elements, such as "share" and "print"
+          buttons or whatever is customary on the platform and user agent.
+        </dd>
+        <dt>
+          <dfn data-dfn-for="display mode">browser</dfn> (default)
+        </dt>
+        <dd>
+          Opens the web application using the platform-specific convention for
+          opening hyperlinks in the user agent (e.g., in a browser tab or a new
+          window).
+        </dd>
+      </dl>
+      <p class="note">
+        The [=display mode/fullscreen=] <a>display mode</a> is orthogonal to,
+        and works independently of, the [[[FULLSCREEN]]]. The [=display
+        mode/fullscreen=] <a>display mode</a> affects the fullscreen state of
+        the browser window, while the [[FULLSCREEN]] API operates on an element
+        contained within the viewport. As such, a web application can have its
+        <a>display mode</a> set to [=display mode/fullscreen=], while
+        `document.fullScreenElement` returns `null`, and `fullscreenEnabled`
+        returns `false`.
       </p>
       <p>
         Once a user agent [=applies=] a particular <a>display mode</a> to an

--- a/index.html
+++ b/index.html
@@ -2542,12 +2542,12 @@
         Display modes
       </h2>
       <p>
-        A <dfn  class="export">display mode</dfn> represents how the web application is being
-        presented within the context of an OS (e.g., in fullscreen, etc.).
-        Display modes correspond to user interface (UI) metaphors and
-        functionality in use on a given platform. The UI conventions of the
-        display modes are purely advisory and implementers are free to
-        interpret them how they best see fit.
+        A <dfn class="export">display mode</dfn> represents how the web
+        application is being presented within the context of an OS (e.g., in
+        fullscreen, etc.). Display modes correspond to user interface (UI)
+        metaphors and functionality in use on a given platform. The UI
+        conventions of the display modes are purely advisory and implementers
+        are free to interpret them how they best see fit.
       </p>
       <p>
         This specification defines the following [=display modes=]:
@@ -2583,7 +2583,8 @@
           buttons or whatever is customary on the platform and user agent.
         </dd>
         <dt>
-          <dfn class="export" data-dfn-for="display mode">browser</dfn> (default)
+          <dfn class="export" data-dfn-for="display mode">browser</dfn>
+          (default)
         </dt>
         <dd>
           Opens the web application using the platform-specific convention for

--- a/index.html
+++ b/index.html
@@ -2542,7 +2542,7 @@
         Display modes
       </h2>
       <p>
-        A <dfn>display mode</dfn> represents how the web application is being
+        A <dfn  class="export">display mode</dfn> represents how the web application is being
         presented within the context of an OS (e.g., in fullscreen, etc.).
         Display modes correspond to user interface (UI) metaphors and
         functionality in use on a given platform. The UI conventions of the
@@ -2554,14 +2554,14 @@
       </p>
       <dl>
         <dt>
-          <dfn data-dfn-for="display mode">fullscreen</dfn>
+          <dfn class="export" data-dfn-for="display mode">fullscreen</dfn>
         </dt>
         <dd>
           Opens the web application with browser UI elements hidden and takes
           up the entirety of the available display area.
         </dd>
         <dt>
-          <dfn data-dfn-for="display mode">standalone</dfn>
+          <dfn class="export" data-dfn-for="display mode">standalone</dfn>
         </dt>
         <dd>
           Opens the web application to look and feel like a standalone native
@@ -2572,7 +2572,7 @@
           bar and/or system back button.
         </dd>
         <dt>
-          <dfn data-dfn-for="display mode">minimal-ui</dfn>
+          <dfn class="export" data-dfn-for="display mode">minimal-ui</dfn>
         </dt>
         <dd>
           This mode is similar to [=display mode/standalone=], but provides the
@@ -2583,7 +2583,7 @@
           buttons or whatever is customary on the platform and user agent.
         </dd>
         <dt>
-          <dfn data-dfn-for="display mode">browser</dfn> (default)
+          <dfn class="export" data-dfn-for="display mode">browser</dfn> (default)
         </dt>
         <dd>
           Opens the web application using the platform-specific convention for

--- a/index.html
+++ b/index.html
@@ -2682,14 +2682,20 @@
       </p>
       <p>
         A user agent MUST reflect the applied <a>display mode</a> of the web
-        application in the '`display-mode`' media feature [[MEDIAQUERIES-5]].
+        application in the <a data-xref-type="css-descriptor" data-xref-for=
+        "@media">`display-mode`</a> media feature [[MEDIAQUERIES-5]].
       </p>
       <p class="note">
-        A user agent will expose the '`display-mode`' media feature
-        irrespective of whether a manifest is being applied to a browsing
-        context. For example, if the end-user puts the application into
-        fullscreen, then the user agent would reflect this change to CSS and
-        scripts via the '`display-mode`' media feature.
+        A user agent will expose the actual display mode being applied — not
+        necessarily the one declared in the manifest — via the
+        <a data-xref-type="css-descriptor" data-xref-for=
+        "@media">`display-mode`</a> media feature, accessible through CSS or
+        JavaScript. Note that this media feature will also reflect other
+        display modes for a web page when a manifest is not being applied. For
+        example, if the end-user puts the page into fullscreen, then the user
+        agent would reflect this change to CSS and scripts via the
+        <a data-xref-type="css-descriptor" data-xref-for=
+        "@media">`display-mode`</a> media feature.
       </p>
     </section>
     <section id="priv-sec">


### PR DESCRIPTION
This text was moved out of the Manifest spec into CSS mediaqueries-5 in
w3c/csswg-drafts#6343, along with the display-mode media feature. The
actual definition of display mode belongs here, while the display-mode
media feature remains in CSS mediaqueries-5.

Closes w3c/csswg-drafts#7306.

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/1039.html" title="Last updated on Apr 12, 2024, 12:13 AM UTC (7c3b5d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1039/482c7fd...mgiuca:7c3b5d9.html" title="Last updated on Apr 12, 2024, 12:13 AM UTC (7c3b5d9)">Diff</a>