### PR TITLE
Use ordered map JSON in id processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -859,7 +859,7 @@
           [=URL/within scope=].
         </p>
         <p>
-          To <dfn>process the `id` member</dfn>, given [=object=] |json:JSON|,
+          To <dfn>process the `id` member</dfn>, given [=ordered map=] |json:JSON|,
           [=ordered map=] |manifest:ordered map|:
         </p>
         <ol class="algorithm">


### PR DESCRIPTION
Use `ordered map` instead of `object` type for consistency with all other processing logic.

This change (choose at least one, delete ones that don't apply):

* Is a "chore" (metadata, formatting, fixing warnings, etc).


Commit message:

Use ordered map JSON in id processing

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1040.html" title="Last updated on Jun 2, 2022, 8:42 PM UTC (735e290)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1040/121f24f...735e290.html" title="Last updated on Jun 2, 2022, 8:42 PM UTC (735e290)">Diff</a>