### PR TITLE
Define an algorithm for launching a web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -2264,6 +2264,10 @@
           |POST resource| and returns an [=application context=].
         </p>
         <p>
+          |Target URL|, if given, MUST be [=manifest/within scope=] of
+          |manifest|.
+        </p>
+        <p>
           Other specifications MAY replace this algorithm's steps with their own
           steps. This replacement will take effect for all invocations
           of [=launching a web application=].

--- a/index.html
+++ b/index.html
@@ -2249,9 +2249,8 @@
           Launching a web application
         </h3>
         <p>
-          At the discretion of the operating system and/or user agent, run the
-          steps to [=launch a web application=] with a
-          [=Document/processed manifest=].
+          At the discretion of the OS or UA, run the steps to
+          [=launch a web application=] with a [=Document/processed manifest=].
         </p>
         <p class="note">
           This would typically take place when the user selects an [=installed=]
@@ -2271,13 +2270,12 @@
           <li>Let |traversable| be the result of
               <a data-cite="html#create-a-fresh-top-level-traversable">
               creating a fresh top-level traversable</a> with |target URL|
-              and |POST resource| (or null if |POST resource| was not given).
+              and |POST resource|.
           </li>
           <li>Let |browsing context| be the |traversable|'s
               <a data-cite="html#nav-bc">active browsing context</a>.
           </li>
-          <li>[=Apply=] |manifest| to |browsing context| prior to the
-              |traversable| [=navigating=] to |target URL|.
+          <li>[=Apply=] |manifest| to |browsing context|.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -2250,19 +2250,21 @@
           following algorithm. The algorithm takes a
           [=Document/processed manifest=] |manifest:processed manifest|, an
           optional |target URL:URL| and an optional
-          <a data-cite="html#post-resource">POST resource</a> or null
-          |post resource| (default null).
+          <a data-cite="html#post-resource">POST resource</a> |POST resource|.
         </p>
         <ol class="algorithm">
-          <li>If <var>url</var> is unset, set <var>url</var> to
+          <li>If |target URL| is null, set |target URL| to
               |manifest|.[=manifest/start_url=].
           </li>
-          <li>Let |client| be the result of
+          <li>Let |traversable| be the result of
               <a data-cite="html#create-a-fresh-top-level-traversable">
-              creating a fresh top-level traversable</a> passing |url| and
-              |post resource|.
+              creating a fresh top-level traversable</a> passing |target URL|
+              and |POST resource|.
           </li>
-          <li>[=Apply=] |manifest| to |client|.
+          <li>Let |browsing context| be the |traversable|'s
+              <a data-cite="html#nav-bc">active browsing context</a>.
+          </li>
+          <li>[=Apply=] |manifest| to |browsing context|.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -2247,8 +2247,9 @@
           Launching a web application
         </h3>
         <p>
-          At the discretion of the OS or UA, run the steps to
-          [=launch a web application=] with a [=Document/processed manifest=].
+          At the discretion of the operating system or user agent, run the steps
+          to [=launch a web application=] with a
+          [=Document/processed manifest=].
         </p>
         <p class="note">
           This would typically take place when the user selects an [=installed=]
@@ -2259,8 +2260,36 @@
           The steps to <dfn data-lt="launching a web application">launch a web
           application</dfn> is given by the following algorithm. The algorithm
           takes a [=Document/processed manifest=] |manifest:processed manifest|,
-          an optional |target URL:URL| and an optional
-          <a data-cite="html#post-resource">POST resource</a> |POST resource|.
+          an optional |target URL:URL|, an optional
+          <a data-cite="html#post-resource">POST resource</a> |POST resource|
+          and returns an [=application context=].
+        </p>
+        <p>
+          Other specifications MAY replace this algorithm's steps with their own
+          steps. This replacement will take effect for all invocations
+          of [=launching a web application=].
+        </p>
+        <p class="note">
+          This algorithm is replaceable to allow an experimental
+          <a href="https://github.com/WICG/web-app-launch">launch_handler</a>
+          manifest field to configure the behavior of all web application
+          launches. The replacement algorithm invokes [=create a new
+          application context=] by default but under certain conditions behaves
+          differently.
+        </p>
+        <ol class="algorithm">
+          <li>Return the result of running the steps to [=create a new
+              application context=] passing |manifest|, |target URL| and
+              |POST resource|.
+          </li>
+        </ol>
+        <p>
+          The steps to <dfn>create a new application context</dfn> is given
+          by the following algorithm. The algorithm takes a
+          [=Document/processed manifest=] |manifest:processed manifest|,
+          an optional |target URL:URL|, an optional
+          <a data-cite="html#post-resource">POST resource</a> |POST resource|
+          and returns an [=application context=].
         </p>
         <ol class="algorithm">
           <li>If |target URL| was not given, set |target URL| to [=start URL=].

--- a/index.html
+++ b/index.html
@@ -1397,6 +1397,11 @@
             [=Document/processed manifest=] are affecting the presentation or
             behavior of a browsing context.
           </p>
+          <p class="note">
+            This gives the user agent an opportunity to apply the relevant
+            values of the manifest, possibly changing the <a>display mode</a>
+            and screen orientation of the web application.
+          </p>
           <p>
             A <a>top-level browsing context</a> that has a manifest applied to
             it is referred to as an <dfn>application context</dfn>.
@@ -1987,7 +1992,7 @@
         <p>
           When <a>shortcut item</a> <var>shortcut</var> having
           <var>manifest</var> is invoked, run the steps to
-          [=launch a web application=] given <var>mainfest</var> and
+          [=launch a web application=] given <var>manifest</var> and
           <var>shortcut.url</var>.
         </p>
       </section>
@@ -2195,16 +2200,14 @@
         bookmark, as opening a web page from a traditional bookmark will not
         have the manifest's properties <a>applied</a> to it.
       </p>
-      <p>
+      <p class="note">
         For example, on user agents that support installation, a web
         application could be presented and launched in a way that, to the
         end-user, is indistinguishable from native applications: such as
         appearing as a labeled icon on the home screen, launcher, or start
-        menu. When launched, the manifest is <a>applied</a> by the user agent
-        to the <a>top-level browsing context</a> prior to the <a>start URL</a>
-        being loaded. This gives the user agent an opportunity to apply the
-        relevant values of the manifest, possibly changing the <a>display
-        mode</a> and screen orientation of the web application. Alternatively,
+        menu. When [=launching a web application=], the manifest is
+        <a>applied</a> by the user agent to the <a>top-level browsing
+        context</a> prior to the <a>start URL</a> being loaded. Alternatively,
         and again as an example, the user agent could <a>install</a> the web
         application into a list of bookmarks within the user agent itself.
       </p>
@@ -2246,25 +2249,35 @@
           Launching a web application
         </h3>
         <p>
-          The steps to <dfn>launch a web application</dfn> is given by the
-          following algorithm. The algorithm takes a
-          [=Document/processed manifest=] |manifest:processed manifest|, an
-          optional |target URL:URL| and an optional
+          At the discretion of the operating system and/or user agent, run the
+          steps to [=launch a web application=] with a
+          [=Document/processed manifest=].
+        </p>
+        <p class="note">
+          This would typically take place when the user selects an [=installed=]
+          web app from an app launching UI surface e.g., a home screen, launcher
+          or start menu.
+        </p>
+        <p>
+          The steps to <dfn data-lt="launching a web application">launch a web
+          application</dfn> is given by the following algorithm. The algorithm
+          takes a [=Document/processed manifest=] |manifest:processed manifest|,
+          an optional |target URL:URL| and an optional
           <a data-cite="html#post-resource">POST resource</a> |POST resource|.
         </p>
         <ol class="algorithm">
-          <li>If |target URL| is null, set |target URL| to
-              |manifest|.[=manifest/start_url=].
+          <li>If |target URL| was not passed, set |target URL| to [=start URL=].
           </li>
           <li>Let |traversable| be the result of
               <a data-cite="html#create-a-fresh-top-level-traversable">
               creating a fresh top-level traversable</a> passing |target URL|
-              and |POST resource|.
+              and |POST resource| (or null if |POST resource| was not passed).
           </li>
           <li>Let |browsing context| be the |traversable|'s
               <a data-cite="html#nav-bc">active browsing context</a>.
           </li>
-          <li>[=Apply=] |manifest| to |browsing context|.
+          <li>[=Apply=] |manifest| to |browsing context| prior to the
+              |traversable| [=navigating=] to |target URL|.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -2275,6 +2275,8 @@
           </li>
           <li>[=Apply=] |manifest| to |browsing context|.
           </li>
+          <li>Return |browsing context|.
+          </li>
         </ol>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -2245,7 +2245,7 @@
         </p>
       </section>
       <section>
-        <h3 id="installation-sec">
+        <h3>
           Launching a web application
         </h3>
         <p>

--- a/index.html
+++ b/index.html
@@ -2248,18 +2248,19 @@
         <p>
           The steps to <dfn>launch a web application</dfn> is given by the
           following algorithm. The algorithm takes a
-          [=Document/processed manifest=] |manifest:processed manifest| and an
-          optional |target URL:URL|.
+          [=Document/processed manifest=] |manifest:processed manifest|, an
+          optional |target URL:URL| and an optional
+          <a data-cite="html#post-resource">post resource</a> or null
+          |post resource| (default null).
         </p>
         <ol class="algorithm">
           <li>If <var>url</var> is unset, set <var>url</var> to
               |manifest|.[=manifest/start_url=].
           </li>
           <li>Let |client| be the result of
-              <a data-cite="html#creating-a-new-top-level-browsing-context">
-              creating a new top-level browsing context</a>.
-          </li>
-          <li>[=Navigate=] |client| passing |url|.
+              <a data-cite="html#create-a-fresh-top-level-traversable">
+              creating a fresh top-level traversable</a> passing |url| and
+              |post resource|.
           </li>
           <li>[=Apply=] |manifest| to |client|.
           </li>

--- a/index.html
+++ b/index.html
@@ -1986,18 +1986,10 @@
         </h3>
         <p>
           When <a>shortcut item</a> <var>shortcut</var> having
-          <var>manifest</var> is invoked, run the following steps:
+          <var>manifest</var> is invoked, run the steps to
+          [=launch a web application=] given <var>mainfest</var> and
+          <var>shortcut.url</var>.
         </p>
-        <ol class="algorithm">
-          <li>Let <var>url</var> be <var>shortcut.url</var>.
-          </li>
-          <li>Let <var>browsing context</var> be the result of creating a new
-          <a>top-level browsing context</a>.
-          </li>
-          <li>
-            <a>Navigate</a> <var>browsing context</var> to <var>url</var>.
-          </li>
-        </ol>
       </section>
       <section>
         <h2>
@@ -2248,6 +2240,30 @@
           [=manifest/short_name=] member might be better suited for the space
           available underneath an icon).
         </p>
+      </section>
+      <section>
+        <h3 id="installation-sec">
+          Launching a web application
+        </h3>
+        <p>
+          The steps to <dfn>launch a web application</dfn> is given by the
+          following algorithm. The algorithm takes a
+          [=Document/processed manifest=] |manifest:processed manifest| and an
+          optional |target URL:URL|.
+        </p>
+        <ol class="algorithm">
+          <li>If <var>url</var> is unset, set <var>url</var> to
+              |manifest|.[=manifest/start_url=].
+          </li>
+          <li>Let |client| be the result of
+              <a data-cite="html#creating-a-new-top-level-browsing-context">
+              creating a new top-level browsing context</a>.
+          </li>
+          <li>[=Navigate=] |client| passing |url|.
+          </li>
+          <li>[=Apply=] |manifest| to |client|.
+          </li>
+        </ol>
       </section>
       <section>
         <h3 id="installation-sec">

--- a/index.html
+++ b/index.html
@@ -2257,7 +2257,8 @@
           or start menu.
         </p>
         <p>
-          The steps to <dfn data-lt="launching a web application">launch a web
+          The steps to
+          <dfn data-lt="launching a web application" data-export="">launch a web
           application</dfn> is given by the following algorithm. The algorithm
           takes a [=Document/processed manifest=] |manifest:processed manifest|,
           an optional |target URL:URL|, an optional [=POST resource=]
@@ -2287,8 +2288,8 @@
           </li>
         </ol>
         <p>
-          The steps to <dfn>create a new application context</dfn> is given
-          by the following algorithm. The algorithm takes a
+          The steps to <dfn data-export="">create a new application context
+          </dfn> is given by the following algorithm. The algorithm takes a
           [=Document/processed manifest=] |manifest:processed manifest|,
           an optional |target URL:URL|, an optional [=POST resource=]
           |POST resource| and returns an [=application context=].

--- a/index.html
+++ b/index.html
@@ -2270,8 +2270,8 @@
         </p>
         <p>
           Other specifications MAY replace this algorithm's steps with their own
-          steps. This replacement will take effect for all invocations
-          of [=launching a web application=].
+          steps. This replacement will take effect for all invocations of
+          [=launch a web application=].
         </p>
         <p class="note">
           This algorithm is replaceable to allow an experimental

--- a/index.html
+++ b/index.html
@@ -2265,7 +2265,7 @@
           |POST resource| and returns an [=application context=].
         </p>
         <p>
-          |Target URL|, if given, MUST be [=manifest/within scope=] of
+          |target URL|, if given, MUST be [=manifest/within scope=] of
           |manifest|.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -2260,9 +2260,8 @@
           The steps to <dfn data-lt="launching a web application">launch a web
           application</dfn> is given by the following algorithm. The algorithm
           takes a [=Document/processed manifest=] |manifest:processed manifest|,
-          an optional |target URL:URL|, an optional
-          <a data-cite="html#post-resource">POST resource</a> |POST resource|
-          and returns an [=application context=].
+          an optional |target URL:URL|, an optional [=POST resource=]
+          |POST resource| and returns an [=application context=].
         </p>
         <p>
           Other specifications MAY replace this algorithm's steps with their own
@@ -2287,17 +2286,15 @@
           The steps to <dfn>create a new application context</dfn> is given
           by the following algorithm. The algorithm takes a
           [=Document/processed manifest=] |manifest:processed manifest|,
-          an optional |target URL:URL|, an optional
-          <a data-cite="html#post-resource">POST resource</a> |POST resource|
-          and returns an [=application context=].
+          an optional |target URL:URL|, an optional [=POST resource=]
+          |POST resource| and returns an [=application context=].
         </p>
         <ol class="algorithm">
           <li>If |target URL| was not given, set |target URL| to [=start URL=].
           </li>
-          <li>Let |traversable| be the result of
-              <a data-cite="html#create-a-fresh-top-level-traversable">
-              creating a fresh top-level traversable</a> with |target URL|
-              and |POST resource|.
+          <li>Let |traversable| be the result of running the steps to [=create
+              a fresh top-level traversable=] with |target URL| and
+              |POST resource|.
           </li>
           <li>Let |browsing context| be the |traversable|'s
               <a data-cite="html#nav-bc">active browsing context</a>.

--- a/index.html
+++ b/index.html
@@ -2261,7 +2261,7 @@
           <dfn data-lt="launching a web application" data-export="">launch a web
           application</dfn> is given by the following algorithm. The algorithm
           takes a [=Document/processed manifest=] |manifest:processed manifest|,
-          an optional |target URL:URL|, an optional [=POST resource=]
+          an optional [=URL=] |target URL:URL|, an optional [=POST resource=]
           |POST resource| and returns an [=application context=].
         </p>
         <p>
@@ -2291,7 +2291,7 @@
           The steps to <dfn data-export="">create a new application context
           </dfn> is given by the following algorithm. The algorithm takes a
           [=Document/processed manifest=] |manifest:processed manifest|,
-          an optional |target URL:URL|, an optional [=POST resource=]
+          an optional [=URL=] |target URL:URL|, an optional [=POST resource=]
           |POST resource| and returns an [=application context=].
         </p>
         <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -2250,7 +2250,7 @@
           following algorithm. The algorithm takes a
           [=Document/processed manifest=] |manifest:processed manifest|, an
           optional |target URL:URL| and an optional
-          <a data-cite="html#post-resource">post resource</a> or null
+          <a data-cite="html#post-resource">POST resource</a> or null
           |post resource| (default null).
         </p>
         <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -1397,11 +1397,6 @@
             [=Document/processed manifest=] are affecting the presentation or
             behavior of a browsing context.
           </p>
-          <p class="note">
-            This gives the user agent an opportunity to apply the relevant
-            values of the manifest, possibly changing the <a>display mode</a>
-            and screen orientation of the web application.
-          </p>
           <p>
             A <a>top-level browsing context</a> that has a manifest applied to
             it is referred to as an <dfn>application context</dfn>.
@@ -2207,9 +2202,12 @@
         appearing as a labeled icon on the home screen, launcher, or start
         menu. When [=launching a web application=], the manifest is
         <a>applied</a> by the user agent to the <a>top-level browsing
-        context</a> prior to the <a>start URL</a> being loaded. Alternatively,
-        and again as an example, the user agent could <a>install</a> the web
-        application into a list of bookmarks within the user agent itself.
+        context</a> prior to the <a>start URL</a> being loaded. This gives the
+        user agent an opportunity to apply the relevant values of the manifest,
+        possibly changing the <a>display mode</a> and screen orientation of the
+        web application. Alternatively, and again as an example, the user agent
+        could <a>install</a> the web application into a list of bookmarks within
+        the user agent itself.
       </p>
       <section>
         <h3>

--- a/index.html
+++ b/index.html
@@ -1992,7 +1992,7 @@
         <p>
           When <a>shortcut item</a> <var>shortcut</var> having
           <var>manifest</var> is invoked, run the steps to
-          [=launch a web application=] given <var>manifest</var> and
+          [=launch a web application=] with <var>manifest</var> and
           <var>shortcut.url</var>.
         </p>
       </section>
@@ -2266,12 +2266,12 @@
           <a data-cite="html#post-resource">POST resource</a> |POST resource|.
         </p>
         <ol class="algorithm">
-          <li>If |target URL| was not passed, set |target URL| to [=start URL=].
+          <li>If |target URL| was not given, set |target URL| to [=start URL=].
           </li>
           <li>Let |traversable| be the result of
               <a data-cite="html#create-a-fresh-top-level-traversable">
-              creating a fresh top-level traversable</a> passing |target URL|
-              and |POST resource| (or null if |POST resource| was not passed).
+              creating a fresh top-level traversable</a> with |target URL|
+              and |POST resource| (or null if |POST resource| was not given).
           </li>
           <li>Let |browsing context| be the |traversable|'s
               <a data-cite="html#nav-bc">active browsing context</a>.


### PR DESCRIPTION
This is in service of: https://github.com/WICG/web-app-launch/issues/67

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

This change adds an algorithm for launching a web app to be used by manifest features that invoke launches like shortcut items, share target, file handling etc. This is also intended to be a point for https://wicg.github.io/web-app-launch/#launching-a-web-app to replace the behaviour with something that can re-use existing web app instances.

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alancutter/manifest/pull/1056.html" title="Last updated on Nov 8, 2022, 4:47 AM UTC (c81c265)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1056/dedfbea...alancutter:c81c265.html" title="Last updated on Nov 8, 2022, 4:47 AM UTC (c81c265)">Diff</a>