### PR TITLE
chore: update "processing a manifest"'s signature

### DIFF
--- a/index.html
+++ b/index.html
@@ -1248,8 +1248,8 @@
           <p>
             The steps for <dfn data-export="" data-local-lt=
             "processing">processing a manifest</dfn> are given by the following
-            algorithm. The algorithm takes [^link^] |el:HTMLLinkElement| and a
-            [=Response=] |response|.
+            algorithm. The algorithm takes [^link^] |el:HTMLLinkElement|, a
+            [=Response=] |response|, and a [=byte sequence=] |bodyBytes|.
           </p>
           <ol class="algorithm">
             <li>Let |document URL:URL| be |el|'s [=Node/node document=]'s
@@ -1258,7 +1258,7 @@
             <li>Assert: |document URL:URL| is not null.
             </li>
             <li>Let |json| be the result of [=parse JSON bytes to an Infra
-            value=] passing |response|'s [=response/body=].
+            value=] passing |bodyBytes|.
             </li>
             <li>If the |json| is a parsing exception, or |json| is not an
             [=ordered map=]:


### PR DESCRIPTION
Commit message:

> chore: update "processing a manifest"'s signature
>
> This commit implements the HTML changes done in whatwg/html#8412:
> "processing a manifest" takes a response whose body has been already
> consumed, so it needs to take the body bytes as a separate parameter.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/manifest/pull/1058.html" title="Last updated on Oct 31, 2022, 12:10 AM UTC (39a67ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1058/cc26cd6...nicolo-ribaudo:39a67ed.html" title="Last updated on Oct 31, 2022, 12:10 AM UTC (39a67ed)">Diff</a>