### PR TITLE
Export processed manifest and application context definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1328,8 +1328,8 @@
             any proprietary and/or other supported members at this point in the
             algorithm.
             </li>
-            <li>Let [=document=]'s <dfn data-dfn-for="Document">processed
-            manifest</dfn> be |manifest|.
+            <li>Let [=document=]'s <dfn data-export="" data-dfn-for="Document">
+            processed manifest</dfn> be |manifest|.
             </li>
           </ol>
         </section>
@@ -1399,7 +1399,8 @@
           </p>
           <p>
             A <a>top-level browsing context</a> that has a manifest applied to
-            it is referred to as an <dfn>application context</dfn>.
+            it is referred to as an <dfn data-export="">application
+            context</dfn>.
           </p>
           <p>
             If an <a>application context</a> is created as a result of the user


### PR DESCRIPTION
This change (choose at least one, delete ones that don't apply):

* Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

This PR exports [processed manifest](https://w3c.github.io/manifest/#dfn-processed-manifest) and [application context](https://w3c.github.io/manifest/#dfn-application-context) for use in https://wicg.github.io/web-app-launch/.

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alancutter/manifest/pull/1062.html" title="Last updated on Nov 9, 2022, 12:26 AM UTC (778f8b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1062/a0808b8...alancutter:778f8b4.html" title="Last updated on Nov 9, 2022, 12:26 AM UTC (778f8b4)">Diff</a>