### PR TITLE
Fix broken active-document reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -2354,15 +2354,15 @@
         </p>
       </aside>
       <p>
-        If the [=application context=]'s [=active document=]'s [=Document/URL=]
-        is not [=manifest/within scope=] of the [=application context=]'s
-        [=Document/processed manifest=], the user agent SHOULD show a prominent
-        UI element indicating the [=Document/URL=] or at least its [=origin=],
-        including whether it is served over a secure connection. This UI SHOULD
-        differ from any UI used when the [=Document/URL=] is [=manifest/within
-        scope=] of the [=application context=]'s [=Document/processed
-        manifest=], in order to make it obvious that the user is navigating off
-        scope.
+        If the [=application context=]'s [=navigatable/active document=]'s
+        [=Document/URL=] is not [=manifest/within scope=] of the [=application
+        context=]'s [=Document/processed manifest=], the user agent SHOULD show
+        a prominent UI element indicating the [=Document/URL=] or at least its
+        [=origin=], including whether it is served over a secure connection.
+        This UI SHOULD differ from any UI used when the [=Document/URL=] is
+        [=manifest/within scope=] of the [=application context=]'s
+        [=Document/processed manifest=], in order to make it obvious that the
+        user is navigating off scope.
       </p>
       <aside class="note">
         <p>

--- a/index.html
+++ b/index.html
@@ -2354,7 +2354,7 @@
         </p>
       </aside>
       <p>
-        If the [=application context=]'s [=navigatable/active document=]'s
+        If the [=application context=]'s [=navigable/active document=]'s
         [=Document/URL=] is not [=manifest/within scope=] of the [=application
         context=]'s [=Document/processed manifest=], the user agent SHOULD show
         a prominent UI element indicating the [=Document/URL=] or at least its


### PR DESCRIPTION
This change (choose at least one, delete ones that don't apply):

* Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

This fixes a ReSpec error. The `[=active document=]` reference is now `[=navigable/active document=]`.

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alancutter/manifest/pull/1063.html" title="Last updated on Nov 8, 2022, 2:15 AM UTC (a94d988)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1063/eecf697...alancutter:a94d988.html" title="Last updated on Nov 8, 2022, 2:15 AM UTC (a94d988)">Diff</a>