### PR TITLE
Minor editorial cleanup / refactor of Manifest processing steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -1275,13 +1275,8 @@
             </li>
             <li>[=Process the `lang` member=] passing |json| and |manifest|.
             </li>
-            <li>[=list/For each=] |member:string| of [=list=] « "name",
-            "short_name" »:
-              <ol>
-                <li>[=Process a text member=] passing |json|, |manifest|, and
-                |member|.
-                </li>
-              </ol>
+            <li>[=Process a text member=] passing |json|, |manifest|, and
+            "name".
             </li>
             <li>[=Process a text member=] passing |json|, |manifest|, and
             "short_name".
@@ -1301,13 +1296,11 @@
             <li>[=Process the `scope` member=] passing |json|, |manifest|, and
             |manifest URL|.
             </li>
-            <li>[=list/For each=] |member:string| of [=list=] « "theme_color",
-            "background_color" »:
-              <ol>
-                <li>[=Process a color member=] passing |json|, |manifest|, and
-                |member|.
-                </li>
-              </ol>
+            <li>[=Process a color member=] passing |json|, |manifest|, and
+            "theme_color".
+            </li>
+            <li>[=Process a color member=] passing |json|, |manifest|, and
+            "background_color".
             </li>
             <li>[=Process the `display` member=] passing |json| and |manifest|.
             </li>

--- a/index.html
+++ b/index.html
@@ -502,6 +502,8 @@
           |json:ordered map| and [=ordered map=] |manifest:ordered map|:
         </p>
         <ol class="algorithm">
+          <li>Set |manifest|["dir"] to "auto".
+          </li>
           <li>If |json|["dir"] doesn't [=map/exist=] or if |json|["dir"] is not
           a [=string=], return.
           </li>
@@ -679,6 +681,8 @@
           |json:ordered map| and [=ordered map=] |manifest:ordered map|:
         </p>
         <ol class="algorithm">
+          <li>Set |manifest|["display"] to "browser".
+          </li>
           <li>If |json|["display"] doesn't [=map/exist=] or |json|["display"]
           is not a a [=string=], return.
           </li>
@@ -773,6 +777,8 @@
           |manifest URL:URL|, and [=URL=] |document URL:URL|:
         </p>
         <ol class="algorithm">
+          <li>Set |manifest|["start_url"] to |document URL|.
+          </li>
           <li>If |json|["start_url"] doesn't [=map/exist=] or
           |json|["start_url"] is not a [=string=], return.
           </li>
@@ -784,8 +790,8 @@
           </li>
           <li>If |start URL| is failure, return.
           </li>
-          <li>If |start URL| is not <a>same origin</a> as <var>document
-          URL</var>, return.
+          <li>If |start URL| is not <a>same origin</a> as |document URL|,
+          return.
           </li>
           <li>Otherwise, set |manifest|["start_url"] to |start URL|.
           </li>
@@ -1267,9 +1273,7 @@
                 </li>
               </ol>
             </li>
-            <li>Let |manifest:ordered map| be a new [=ordered map=] «[
-            "display" → "browser", "dir" → "auto", "start_url" → |document URL|
-            ]».
+            <li>Let |manifest:ordered map| be an empty [=ordered map=].
             </li>
             <li>[=Process the `dir` member=] passing |json| and |manifest|.
             </li>

--- a/index.html
+++ b/index.html
@@ -1291,8 +1291,7 @@
             <li>[=Process the `start_url` member=] passing |json|, |manifest|,
             |manifest URL|, and |document URL|.
             </li>
-            <li>[=Process the `id` member=] passing |json|, |manifest| and
-            |document URL|.
+            <li>[=Process the `id` member=] passing |json| and |manifest|.
             </li>
             <li>If the [=document=]'s [=document|processed manifest=] is not
             null, and [=document=]'s [=document|processed manifest=]'s id is


### PR DESCRIPTION
This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

Minor editorial cleanup / refactor of Manifest processing steps.

- Fixed call to "process the id member" (removed the document URL argument which is not actually accepted by that algorithm).
- Removed unnecessarily complex for loops over ~2 members when it's more readable to just have a separate step for each member.
- Use Respec-style syntax instead of HTML.
- Moved default values into individual processing steps. This keeps the relevant info about the default values of members closely related to the other relevant material about that member. It's also consistent with how the rest of the members (e.g. scope) treat default values. And prevents possible errors where the incorrect default value is used by an intermediate step in between assigning the default and assigning the actual value.

Pre-work for #668.

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* editorial:


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/1066.html" title="Last updated on Jan 25, 2023, 12:57 AM UTC (d720167)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1066/7d41b99...mgiuca:d720167.html" title="Last updated on Jan 25, 2023, 12:57 AM UTC (d720167)">Diff</a>