### PR TITLE
Allow manifest processing to be invoked without going through an HTML document

### DIFF
--- a/index.html
+++ b/index.html
@@ -1383,14 +1383,14 @@
             The [=processing a manifest=] steps are invoked by [[HTML]]'s
             processing steps for the [^link^] element, but MAY also be invoked
             by the user agent to process a manifest without an associated
-            document.
+            [=document=].
           </p>
           <p>
-            In this case, the user agent SHOULD ensure that, at least at some
+            In this case, the user agent SHOULD ensure that at least at some
             point in the past:
           </p>
           <ul>
-            <li>there was at least one page which is [=same origin=] as
+            <li>there was at least one [=document=] that is [=same origin=] as
             |document URL:URL| that has a [^link^] element
             |linkElement:HTMLLinkElement| with a [^link/rel^] of
             [^link/rel/manifest^] and a [^link/href^] that resolves to
@@ -1407,7 +1407,7 @@
           <p>
             (The [[HTML]] steps automatically ensure this.)
           </p>
-          <div class="note">
+          <aside class="note">
             <p>
               This provision allows user agents to perform app installations
               using a manifest without having to first load a document that
@@ -1429,7 +1429,7 @@
               the manifest is fetched with or without credentials, as agreed by
               both origins, as it would if going directly through the document.
             </p>
-          </div>
+          </aside>
         </section>
         <section>
           <h3 id="applying">

--- a/index.html
+++ b/index.html
@@ -1254,15 +1254,10 @@
           <p>
             The steps for <dfn data-export="" data-local-lt=
             "processing">processing a manifest</dfn> are given by the following
-            algorithm. The algorithm takes [^link^] |el:HTMLLinkElement|, a
-            [=Response=] |response|, and a [=byte sequence=] |bodyBytes|.
+            algorithm. The algorithm takes a [=URL=] |document URL:URL|, a
+            [=URL=] |manifest URL:URL|, and a [=byte sequence=] |bodyBytes|.
           </p>
           <ol class="algorithm">
-            <li>Let |document URL:URL| be |el|'s [=Node/node document=]'s
-            [=Document/URL=].
-            </li>
-            <li>Assert: |document URL:URL| is not null.
-            </li>
             <li>Let |json| be the result of [=parse JSON bytes to an Infra
             value=] passing |bodyBytes|.
             </li>
@@ -1284,8 +1279,6 @@
             </li>
             <li>[=Process a text member=] passing |json|, |manifest|, and
             "short_name".
-            </li>
-            <li>Let |manifest URL:URL| be |response|'s [=response/URL=].
             </li>
             <li>[=Process the `start_url` member=] passing |json|, |manifest|,
             |manifest URL|, and |document URL|.

--- a/index.html
+++ b/index.html
@@ -1238,8 +1238,8 @@
             to process a manifest without an associated document. In this case,
             the user agent MUST supply a |document URL| which is either <a>same
             origin</a> as |manifest URL|, or <a>same origin</a> as at least one
-            page with a [^link^] element of type "manifest" that references the
-            given |manifest URL|.
+            page with a [^link^] element of type [^link/rel/manifest^] that
+            references the given |manifest URL|.
           </p>
           <p class="note">
             This provision allows user agents to perform app installations

--- a/index.html
+++ b/index.html
@@ -1385,16 +1385,16 @@
             by the user agent to process a manifest without an associated
             document. In this case, the user agent MUST supply a |document URL|
             which is either <a>same origin</a> as |manifest URL|, or <a>same
-            origin</a> as at least one page with a [^link^] element of type
-            [^link/rel/manifest^] that references the given |manifest URL|.
+            origin</a> as at least one page on origin |linkOrigin| with a
+            [^link^] element |linkElement| of type [^link/rel/manifest^] that
+            references the given |manifest URL|.
           </p>
           <p>
             Additionally, the user agent SHOULD ensure that the |bodyBytes|
             data was fetched with a [=CORS Request=] whose <a data-xref-type=
-            "http-header">`Origin`</a> matches a page with a [^link^] element
-            of type [^link/rel/manifest^] that references the given |manifest
-            URL|, and that its [=Request/credentials mode=] is set to the
-            [=CORS settings attribute credentials mode=] for that [^link^]'s
+            "http-header">`Origin`</a> is |linkOrigin|, and whose
+            [=Request/credentials mode=] is set to the [=CORS settings
+            attribute credentials mode=] for |linkElement|'s
             [^link/crossorigin^] attribute. (The [[HTML]] steps automatically
             ensure this.)
           </p>

--- a/index.html
+++ b/index.html
@@ -1383,35 +1383,53 @@
             The [=processing a manifest=] steps are invoked by [[HTML]]'s
             processing steps for the [^link^] element, but MAY also be invoked
             by the user agent to process a manifest without an associated
-            document. In this case, the user agent MUST supply a |document URL|
-            which is either <a>same origin</a> as |manifest URL|, or <a>same
-            origin</a> as at least one page on origin |linkOrigin| with a
-            [^link^] element |linkElement| of type [^link/rel/manifest^] that
-            references the given |manifest URL|.
+            document.
           </p>
           <p>
-            Additionally, the user agent SHOULD ensure that the |bodyBytes|
-            data was fetched with a [=CORS Request=] whose <a data-xref-type=
-            "http-header">`Origin`</a> is |linkOrigin|, and whose
-            [=Request/credentials mode=] is set to the [=CORS settings
-            attribute credentials mode=] for |linkElement|'s
-            [^link/crossorigin^] attribute. (The [[HTML]] steps automatically
-            ensure this.)
+            In this case, the user agent SHOULD ensure that, at least at some
+            point in the past:
           </p>
-          <p class="note">
-            This provision allows user agents to perform app installations
-            using a manifest without having to first load a document that links
-            to the manifest (e.g. when installing an app onto the user's device
-            via a sync service). But the above requirement forces the user
-            agent to verify that, when an application scope is on origin A and
-            the manifest is on a different origin B, there is a bidirectional
-            relationship between the two origins: that at least some page on
-            origin A links to the manifest on origin B. (Otherwise, it would be
-            possible for a manifest on origin B to control the metadata for an
-            unaffiliated app on origin A.) Also, the user agent is expected to
-            fetch the manifest using the same CORS settings as it would if
-            going directly through the document.
+          <ul>
+            <li>there was at least one page which is [=same origin=] as
+            |document URL:URL| that has a [^link^] element
+            |linkElement:HTMLLinkElement| with a [^link/rel^] of
+            [^link/rel/manifest^] and a [^link/href^] that resolves to
+            |manifest URL:URL|, and that
+            </li>
+            <li>if |manifest URL| is not [=same origin=] as |document URL|, the
+            |bodyBytes:byte sequence| data was fetched with a [=CORS Request=]
+            whose <a data-xref-type="http-header">`Origin`</a> is |document
+            URL|'s [=url/origin=], and whose [=Request/credentials mode=] is
+            set to the [=CORS settings attribute credentials mode=] for
+            |linkElement|'s [^link/crossorigin^] attribute.
+            </li>
+          </ul>
+          <p>
+            (The [[HTML]] steps automatically ensure this.)
           </p>
+          <div class="note">
+            <p>
+              This provision allows user agents to perform app installations
+              using a manifest without having to first load a document that
+              links to the manifest (e.g. when installing an app onto the
+              user's device via a sync service). But the above recommendations
+              ask the user agent to verify that, when an application scope is
+              on origin A and the manifest is on a different origin B, there is
+              a bidirectional relationship between the two origins.
+            </p>
+            <p>
+              The first check ensures that at least some page on origin A links
+              to the manifest on origin B (otherwise, it would be possible for
+              a manifest on origin B to control the metadata for an
+              unaffiliated app on origin A).
+            </p>
+            <p>
+              The second check ensures that origin B allows (via the [=CORS
+              protocol=]) its manifest to be applied by origin A, and also that
+              the manifest is fetched with or without credentials, as agreed by
+              both origins, as it would if going directly through the document.
+            </p>
+          </div>
         </section>
         <section>
           <h3 id="applying">

--- a/index.html
+++ b/index.html
@@ -1246,11 +1246,12 @@
             using a manifest without having to first load a document that links
             to the manifest (e.g. when installing an app onto the user's device
             via a sync service). But the above requirement forces the user
-            agent to verify that, for manifests that are not on the same origin
-            as the pages in the application scope, that at least some page on
-            the origin of the application scope applies that manifest.
-            (Otherwise, it would be possible for a manifest to control the
-            metadata for an unaffiliated app.)
+            agent to verify that, when an application scope is on origin A and
+            the manifest is on a different origin B, there is a bidirectional
+            relationship between the two origins: that at least some page on
+            origin A links to the manifest on origin B. (Otherwise, it would be
+            possible for a manifest on origin B to control the metadata for an
+            unaffiliated app on origin A.)
           </p>
           <p>
             When instructed to <dfn>ignore</dfn>, the user agent MUST act as if

--- a/index.html
+++ b/index.html
@@ -1386,8 +1386,9 @@
             [=document=].
           </p>
           <p>
-            In this case, the user agent SHOULD ensure that at least at some
-            point in the past:
+            In this case, to match the guarantees made by the corresponding
+            steps in [[HTML]], the user agent SHOULD ensure that at least at
+            some point in the past:
           </p>
           <ul>
             <li>there was at least one [=document=] that is [=same origin=] as
@@ -1397,17 +1398,14 @@
             |manifest URL:URL|, and that
             </li>
             <li>if |manifest URL| is not [=same origin=] as |document URL|, the
-            |bodyBytes:byte sequence| data was fetched with a [=CORS Request=]
-            whose <a data-xref-type="http-header">`Origin`</a> is |document
-            URL|'s [=url/origin=], and whose [=Request/credentials mode=] is
-            set to the [=CORS settings attribute credentials mode=] for
-            |linkElement|'s [^link/crossorigin^] attribute.
+            |bodyBytes:byte sequence| data was [=fetch|fetched=] with a [=CORS
+            Request=] whose <a data-xref-type="http-header">`Origin`</a> is
+            |document URL|'s [=url/origin=], and whose [=Request/credentials
+            mode=] is set to the [=CORS settings attribute credentials mode=]
+            for |linkElement|'s [^link/crossorigin^] attribute.
             </li>
           </ul>
-          <p>
-            (The [[HTML]] steps automatically ensure this.)
-          </p>
-          <aside class="note">
+          <aside class="note" title="The rationale for these checks">
             <p>
               This provision allows user agents to perform app installations
               using a manifest without having to first load a document that

--- a/index.html
+++ b/index.html
@@ -1233,6 +1233,26 @@
             Processing the manifest
           </h3>
           <p>
+            These processing steps are invoked by [[HTML]]'s processing steps
+            for the [^link^] element, but MAY also be invoked by the user agent
+            to process a manifest without an associated document. In this case,
+            the user agent MUST supply a |document URL| which is either <a>same
+            origin</a> as |manifest URL|, or <a>same origin</a> as at least one
+            page with a [^link^] element of type "manifest" that references the
+            given |manifest URL|.
+          </p>
+          <p class="note">
+            This provision allows user agents to perform app installations
+            using a manifest without having to first load a document that links
+            to the manifest (e.g. when installing an app onto the user's device
+            via a sync service). But the above requirement forces the user
+            agent to verify that, for manifests that are not on the same origin
+            as the pages in the application scope, that at least some page on
+            the origin of the application scope applies that manifest.
+            (Otherwise, it would be possible for a manifest to control the
+            metadata for an unaffiliated app.)
+          </p>
+          <p>
             When instructed to <dfn>ignore</dfn>, the user agent MUST act as if
             whatever manifest, member, or value caused the condition is absent.
           </p>

--- a/index.html
+++ b/index.html
@@ -1233,39 +1233,6 @@
             Processing the manifest
           </h3>
           <p>
-            These processing steps are invoked by [[HTML]]'s processing steps
-            for the [^link^] element, but MAY also be invoked by the user agent
-            to process a manifest without an associated document. In this case,
-            the user agent MUST supply a |document URL| which is either <a>same
-            origin</a> as |manifest URL|, or <a>same origin</a> as at least one
-            page with a [^link^] element of type [^link/rel/manifest^] that
-            references the given |manifest URL|.
-          </p>
-          <p>
-            Additionally, the user agent SHOULD ensure that the |bodyBytes|
-            data was fetched with a [=CORS Request=] whose <a data-xref-type=
-            "http-header">`Origin`</a> matches a page with a [^link^] element
-            of type [^link/rel/manifest^] that references the given |manifest
-            URL|, and that its [=Request/credentials mode=] is set to the
-            [=CORS settings attribute credentials mode=] for that [^link^]'s
-            [^link/crossorigin^] attribute. (The [[HTML]] steps automatically
-            ensure this.)
-          </p>
-          <p class="note">
-            This provision allows user agents to perform app installations
-            using a manifest without having to first load a document that links
-            to the manifest (e.g. when installing an app onto the user's device
-            via a sync service). But the above requirement forces the user
-            agent to verify that, when an application scope is on origin A and
-            the manifest is on a different origin B, there is a bidirectional
-            relationship between the two origins: that at least some page on
-            origin A links to the manifest on origin B. (Otherwise, it would be
-            possible for a manifest on origin B to control the metadata for an
-            unaffiliated app on origin A.) Also, the user agent is expected to
-            fetch the manifest using the same CORS settings as it would if
-            going directly through the document.
-          </p>
-          <p>
             When instructed to <dfn>ignore</dfn>, the user agent MUST act as if
             whatever manifest, member, or value caused the condition is absent.
           </p>
@@ -1407,6 +1374,44 @@
             <li>Set |map|[member] to the value of |json|[|member|].
             </li>
           </ol>
+        </section>
+        <section>
+          <h3>
+            Processing the manifest without a document
+          </h3>
+          <p>
+            The [=processing a manifest=] steps are invoked by [[HTML]]'s
+            processing steps for the [^link^] element, but MAY also be invoked
+            by the user agent to process a manifest without an associated
+            document. In this case, the user agent MUST supply a |document URL|
+            which is either <a>same origin</a> as |manifest URL|, or <a>same
+            origin</a> as at least one page with a [^link^] element of type
+            [^link/rel/manifest^] that references the given |manifest URL|.
+          </p>
+          <p>
+            Additionally, the user agent SHOULD ensure that the |bodyBytes|
+            data was fetched with a [=CORS Request=] whose <a data-xref-type=
+            "http-header">`Origin`</a> matches a page with a [^link^] element
+            of type [^link/rel/manifest^] that references the given |manifest
+            URL|, and that its [=Request/credentials mode=] is set to the
+            [=CORS settings attribute credentials mode=] for that [^link^]'s
+            [^link/crossorigin^] attribute. (The [[HTML]] steps automatically
+            ensure this.)
+          </p>
+          <p class="note">
+            This provision allows user agents to perform app installations
+            using a manifest without having to first load a document that links
+            to the manifest (e.g. when installing an app onto the user's device
+            via a sync service). But the above requirement forces the user
+            agent to verify that, when an application scope is on origin A and
+            the manifest is on a different origin B, there is a bidirectional
+            relationship between the two origins: that at least some page on
+            origin A links to the manifest on origin B. (Otherwise, it would be
+            possible for a manifest on origin B to control the metadata for an
+            unaffiliated app on origin A.) Also, the user agent is expected to
+            fetch the manifest using the same CORS settings as it would if
+            going directly through the document.
+          </p>
         </section>
         <section>
           <h3 id="applying">

--- a/index.html
+++ b/index.html
@@ -1241,6 +1241,16 @@
             page with a [^link^] element of type [^link/rel/manifest^] that
             references the given |manifest URL|.
           </p>
+          <p>
+            Additionally, the user agent SHOULD ensure that the |bodyBytes|
+            data was fetched with a [=CORS Request=] whose <a data-xref-type=
+            "http-header">`Origin`</a> matches a page with a [^link^] element
+            of type [^link/rel/manifest^] that references the given |manifest
+            URL|, and that its [=Request/credentials mode=] is set to the
+            [=CORS settings attribute credentials mode=] for that [^link^]'s
+            [^link/crossorigin^] attribute. (The [[HTML]] steps automatically
+            ensure this.)
+          </p>
           <p class="note">
             This provision allows user agents to perform app installations
             using a manifest without having to first load a document that links
@@ -1251,7 +1261,9 @@
             relationship between the two origins: that at least some page on
             origin A links to the manifest on origin B. (Otherwise, it would be
             possible for a manifest on origin B to control the metadata for an
-            unaffiliated app on origin A.)
+            unaffiliated app on origin A.) Also, the user agent is expected to
+            fetch the manifest using the same CORS settings as it would if
+            going directly through the document.
           </p>
           <p>
             When instructed to <dfn>ignore</dfn>, the user agent MUST act as if


### PR DESCRIPTION
Closes #1068

This change (choose at least one, delete ones that don't apply):

* Adds new normative recommendations or optional items
* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

Allow manifest processing to be invoked without going through an HTML document.

Manifest processing: Replaces the link and response parameters with document URL and manifest URL. This was limiting the ability to call the processing algorithm from outside an HTML document context.

Note that the only call to this algorithm is in the HTML spec, which needs to be updated simultaneously to use the new interface.
 
Adds new normative text allowing user agents to invoke the processing steps without a document, provided that
they supply a valid document URL and if the document URL is on a different origin to the manifest, there is a page on the document's origin that links to the manifest.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/1069.html" title="Last updated on Apr 27, 2023, 3:04 AM UTC (3d03340)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1069/0252939...mgiuca:3d03340.html" title="Last updated on Apr 27, 2023, 3:04 AM UTC (3d03340)">Diff</a>