### PR TITLE
Editorial: Remove “at risk” warning for monochrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -1834,7 +1834,6 @@
         <h2>
           Monochrome icons and solid fills
         </h2>
-        <aside class="issue atrisk" data-number="905"></aside>
         <p>
           Some platforms enforce that icons be displayed with a <dfn>solid
           fill</dfn> such as a single color, where only the transparency of the


### PR DESCRIPTION
Closes #905

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

Remove “at risk” warning for the `monochrome` icon purpose.

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change
