### PR TITLE
Editorial: Consistent manifest naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-This repository is the home of the :star: **[Web App Manifest](https://www.w3.org/TR/appmanifest/)** :star: specification being worked on by
+This repository is the home of the :star: **[Web Application Manifest](https://www.w3.org/TR/appmanifest/)** :star: specification being worked on by
 the [Web Applications Working Group](https://www.w3.org/2019/webapps/).
 
 ## Useful links
 * [Explainer](https://github.com/w3c/manifest/blob/gh-pages/explainer.md)
-* [The Web App Manifest specification](https://www.w3.org/TR/appmanifest/)
+* [The Web Application Manifest specification](https://www.w3.org/TR/appmanifest/)
 * [App Information supplement](https://github.com/w3c/manifest-app-info)
 * [Use cases and requirements](https://w3c-webmob.github.io/installable-webapps/)
 * [The Web Applications WG homepage](https://www.w3.org/2019/webapps/)

--- a/explainer.md
+++ b/explainer.md
@@ -123,7 +123,7 @@ If you omit the icons, the browser just falls back to looking for `<link rel="ic
 
 TBW.
 
-More information about purpose can be found in the [Web App Manifest spec](https://www.w3.org/TR/appmanifest/#purpose-member).
+More information about purpose can be found in the [Web Application Manifest spec](https://www.w3.org/TR/appmanifest/#purpose-member).
 
 ## Display modes and orientation
 Apps need to be able to control how they are to be displayed when they start-up. If it’s a game, it might need to be in full-screen and possibly in landscape mode. In order to do this, the manifest format provides you with two properties.
@@ -284,9 +284,9 @@ The manifest, and Progressive Web Apps are implemented in Chrome, Opera, and Sam
 
 ## Interaction with Web Crawlers
 
-Like other web resources, a web app manifest should be accessible to any web browser or web crawler.
+Like other web resources, a web application manifest should be accessible to any web browser or web crawler.
 
-If a web app developer wants to inform web crawlers of a desire for the file not to be crawled, the developer MAY do so by including the web app manifest in a robots.txt file.
+If a web app developer wants to inform web crawlers of a desire for the file not to be crawled, the developer MAY do so by including the web application manifest in a robots.txt file.
 This is further described in the [robots.txt](http://www.robotstxt.org/) protocol.
 A web app developer could also use the `X-Robots-Tag` HTTP header.
 

--- a/index.html
+++ b/index.html
@@ -3060,12 +3060,12 @@
         Application Information
       </h2>
       <p>
-        Several members of the Web App Manifest provide additional metadata
-        related to how the web application may be presented in the context of a
-        digital storefront, installation dialog, or other surfaces where the
-        web application may be marketed or distributed. In an effort to support
-        these use cases better, the following members have been moved into
-        [[[manifest-app-info]]]:
+        Several members of the Web Application Manifest provide additional
+        metadata related to how the web application may be presented in the
+        context of a digital storefront, installation dialog, or other surfaces
+        where the web application may be marketed or distributed. In an effort
+        to support these use cases better, the following members have been
+        moved into [[[manifest-app-info]]]:
       </p>
       <ul>
         <li>`categories`


### PR DESCRIPTION
Changes all occurrences of "Web App Manifest" to "Web Application Manifest", as the spec was renamed at some point.

~Closes #???~

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)
* Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message: Editorial: ensure consistency in manifest naming

(Fill in. If making normative changes, describe exactly what the behavioral
difference will be.)

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1099.html" title="Last updated on Nov 15, 2023, 3:48 AM UTC (388bcfa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1099/180d5df...388bcfa.html" title="Last updated on Nov 15, 2023, 3:48 AM UTC (388bcfa)">Diff</a>