### PR TITLE
Editorial: remove “commonly” to reflect actual JSON encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -2648,8 +2648,8 @@
         as "high value" (particularly from a privacy perspective).
       </p>
       <p>
-        As the manifest format is JSON and will commonly be encoded using
-        [[UNICODE]], the security considerations described in [[JSON]] and
+        As the manifest format is JSON and will be encoded using [[UNICODE]],
+        the security considerations described in [[JSON]] and
         [[UNICODE-SECURITY]] apply. In addition, because there is no way to
         prevent developers from including custom/unrestrained data in a
         <a>manifest</a>, implementors need to impose their own


### PR DESCRIPTION
Closes #1089

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

Editorial: remove “commonly” to reflect actual JSON encoding

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1100.html" title="Last updated on Nov 15, 2023, 3:46 AM UTC (a4c5835)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1100/662cc34...a4c5835.html" title="Last updated on Nov 15, 2023, 3:46 AM UTC (a4c5835)">Diff</a>