### PR TITLE
chore: Fix grammar in `id` section

### DIFF
--- a/index.html
+++ b/index.html
@@ -890,7 +890,7 @@
         </ol>
         <aside class="example" title="Resulting ids">
           <p>
-            Below table shows some example `id`s resulting from the [=process
+            The table below shows some example `id`s resulting from the [=process
             the `id` member=] steps.
           </p>
           <table class="data">
@@ -1008,9 +1008,9 @@
           <p>
             Since [=manifest/id=] is resolved against [=manifest/start_url=]'s
             [=URL/origin=], providing "../foo", "foo", "/foo", "./foo" all
-            resolves to the same [=identifier=]. It is As such, best practice
+            resolves to the same [=identifier=]. As such, best practice
             is to use a leading "/" to be explicit that the id is a
-            root-relative url path. Also, standard encoding/decoding rules are
+            root-relative URL path. Also, standard encoding/decoding rules
             apply to the id processing algorithm, as per the [[[URL]]].
           </p>
         </aside>


### PR DESCRIPTION
This change (choose at least one, delete ones that don't apply):

* Is a "chore" (metadata, formatting, fixing warnings, etc).
Commit message: Fix grammar in `id` section


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1102.html" title="Last updated on Oct 12, 2023, 10:05 AM UTC (e76fe1c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1102/115a6bd...e76fe1c.html" title="Last updated on Oct 12, 2023, 10:05 AM UTC (e76fe1c)">Diff</a>