### PR TITLE
[Editorial] Fixes grammar from "A" to "An"

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
         Web Application Manifest
       </h2>
       <p>
-        A <dfn data-export="" data-lt="manifest" data-local-lt=
+        An <dfn data-export="" data-lt="manifest" data-local-lt=
         "manifest's">application manifest</dfn> is a [[JSON]] document that
         contains startup parameters and application defaults for when a web
         application is launched.


### PR DESCRIPTION
This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

Fixes a grammar error.
Changes "A application manifest" to "An application manifest".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/YummyBacon5/manifest/pull/1103.html" title="Last updated on Oct 28, 2023, 12:01 AM UTC (9a0025e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1103/af35ef4...YummyBacon5:9a0025e.html" title="Last updated on Oct 28, 2023, 12:01 AM UTC (9a0025e)">Diff</a>