### PR TITLE
Replace ref to obsoleted RFC7540 with ref to RFC9110

### DIFF
--- a/index.html
+++ b/index.html
@@ -3208,8 +3208,8 @@
           The server that hosts the web application could attempt to
           predetermine the end-user's language by using <a href=
           "https://en.wikipedia.org/wiki/Geotargeting">geotargeting</a> or by
-          using content negotiation (e.g., using [[RFC7540]]'s
-          "`Accept-Language`" header, or even a custom HTTP header).
+          using content negotiation (e.g., using an HTTP "`Accept-Language`"
+          header [[RFC9110]], or even a custom HTTP header).
         </dd>
       </dl>
       <p>


### PR DESCRIPTION
This change:

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

The spec mentions RFC7540 when it talks about content negotiation. RFC7540 has been obsoleted by RFC9113, so reference should be updated.

Now, the prose is a bit clunky because it seems to suggest that RFC7540 defines the `"Accept-Language"` HTTP header, whereas it does not. Rather than replacing the reference with a reference to RFC9113, this update rather targets RFC9110, where `"Accept-Language"` is defined.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/manifest/pull/1106.html" title="Last updated on Nov 27, 2023, 9:49 AM UTC (0ccc3fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1106/f54c962...tidoust:0ccc3fd.html" title="Last updated on Nov 27, 2023, 9:49 AM UTC (0ccc3fd)">Diff</a>