### PR TITLE
chore: Export the terms "manifest URL" and "start URL"

### DIFF
--- a/index.html
+++ b/index.html
@@ -759,7 +759,7 @@
         <p>
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">start_url</dfn></code> member is a <a>string</a> that
-          represents the <dfn data-dfn-for="manifest" class="export">start URL</dfn> , which is
+          represents the <dfn class="export">start URL</dfn> , which is
           <a>URL</a> that the developer would prefer the user agent load when
           the user launches the web application (e.g., when the user clicks on
           the icon of the web application from a device's application menu or

--- a/index.html
+++ b/index.html
@@ -607,7 +607,7 @@
         <aside class="note" title="Default scope">
           <p>
             The "default scope" (when [=manifest/scope=] member is missing,
-            empty, or failure) is the [=start URL=], but with its filename,
+            empty, or failure) is the [=manifest/start URL=], but with its filename,
             query, and fragment removed.
           </p>
         </aside>

--- a/index.html
+++ b/index.html
@@ -890,8 +890,8 @@
         </ol>
         <aside class="example" title="Resulting ids">
           <p>
-            The table below shows some example `id`s resulting from the [=process
-            the `id` member=] steps.
+            The table below shows some example `id`s resulting from the
+            [=process the `id` member=] steps.
           </p>
           <table class="data">
             <tr>
@@ -1008,10 +1008,10 @@
           <p>
             Since [=manifest/id=] is resolved against [=manifest/start_url=]'s
             [=URL/origin=], providing "../foo", "foo", "/foo", "./foo" all
-            resolves to the same [=identifier=]. As such, best practice
-            is to use a leading "/" to be explicit that the id is a
-            root-relative URL path. Also, standard encoding/decoding rules
-            apply to the id processing algorithm, as per the [[[URL]]].
+            resolves to the same [=identifier=]. As such, best practice is to
+            use a leading "/" to be explicit that the id is a root-relative URL
+            path. Also, standard encoding/decoding rules apply to the id
+            processing algorithm, as per the [[[URL]]].
           </p>
         </aside>
       </section>

--- a/index.html
+++ b/index.html
@@ -607,7 +607,7 @@
         <aside class="note" title="Default scope">
           <p>
             The "default scope" (when [=manifest/scope=] member is missing,
-            empty, or failure) is the [=manifest/start URL=], but with its filename,
+            empty, or failure) is the [=start URL=], but with its filename,
             query, and fragment removed.
           </p>
         </aside>

--- a/index.html
+++ b/index.html
@@ -840,7 +840,7 @@
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">id</dfn></code> member is a <a>string</a> that represents
           the <dfn>identity</dfn> for the application. The [=identity=] takes
-          the form of a URL, which is same origin as the [=manifest/start URL=].
+          the form of a URL, which is same origin as the [=start URL=].
         </p>
         <p>
           The [=identity=] is used by user agents to uniquely identify the

--- a/index.html
+++ b/index.html
@@ -161,8 +161,8 @@
         application is launched.
       </p>
       <p>
-        A manifest has an associated <dfn>manifest URL</dfn>, which is the
-        [[URL]] from which the <a>manifest</a> was fetched.
+        A manifest has an associated <dfn data-export="">manifest URL</dfn>,
+        which is the [[URL]] from which the <a>manifest</a> was fetched.
       </p>
       <p>
         A [=manifest=] can have any of the following members at its root, all
@@ -759,10 +759,11 @@
         <p>
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">start_url</dfn></code> member is a <a>string</a> that
-          represents the <dfn>start URL</dfn> , which is <a>URL</a> that the
-          developer would prefer the user agent load when the user launches the
-          web application (e.g., when the user clicks on the icon of the web
-          application from a device's application menu or homescreen).
+          represents the <dfn data-export="">start URL</dfn> , which is
+          <a>URL</a> that the developer would prefer the user agent load when
+          the user launches the web application (e.g., when the user clicks on
+          the icon of the web application from a device's application menu or
+          homescreen).
         </p>
         <p>
           The [=manifest/start_url=] member is purely advisory, and a user

--- a/index.html
+++ b/index.html
@@ -823,7 +823,7 @@
           <p>
             Given the above, it is RECOMMENDED that, upon installation, or any
             time thereafter, a user agent allows the user to inspect and, if
-            necessary, modify the [=manifest/start URL=] of an application.
+            necessary, modify the [=start URL=] of an application.
           </p>
           <p>
             Additionally, developers MUST NOT use the [=manifest/start URL=] to include

--- a/index.html
+++ b/index.html
@@ -607,8 +607,8 @@
         <aside class="note" title="Default scope">
           <p>
             The "default scope" (when [=manifest/scope=] member is missing,
-            empty, or failure) is the start URL, but with its filename, query,
-            and fragment removed.
+            empty, or failure) is the [=start URL=], but with its filename,
+            query, and fragment removed.
           </p>
         </aside>
         <p>
@@ -822,12 +822,12 @@
           <p>
             Given the above, it is RECOMMENDED that, upon installation, or any
             time thereafter, a user agent allows the user to inspect and, if
-            necessary, modify the <a>start URL</a> of an application.
+            necessary, modify the [=start URL=] of an application.
           </p>
           <p>
-            Additionally, developers MUST NOT use the <a>start URL</a> to
-            include information that uniquely identifies a user (e.g.,
-            "?user=123" or "/user/123/", or "https://user123.foo.bar").
+            Additionally, developers MUST NOT use the [=start URL=] to include
+            information that uniquely identifies a user (e.g., "?user=123" or
+            "/user/123/", or "https://user123.foo.bar").
           </p>
         </section>
       </section>
@@ -839,7 +839,7 @@
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">id</dfn></code> member is a <a>string</a> that represents
           the <dfn>identity</dfn> for the application. The [=identity=] takes
-          the form of a URL, which is same origin as the start URL.
+          the form of a URL, which is same origin as the [=start URL=].
         </p>
         <p>
           The [=identity=] is used by user agents to uniquely identify the

--- a/index.html
+++ b/index.html
@@ -759,7 +759,7 @@
         <p>
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">start_url</dfn></code> member is a <a>string</a> that
-          represents the <dfn data-export="">start URL</dfn> , which is
+          represents the <dfn data-dfn-for="manifest" class="export">start URL</dfn> , which is
           <a>URL</a> that the developer would prefer the user agent load when
           the user launches the web application (e.g., when the user clicks on
           the icon of the web application from a device's application menu or
@@ -823,10 +823,10 @@
           <p>
             Given the above, it is RECOMMENDED that, upon installation, or any
             time thereafter, a user agent allows the user to inspect and, if
-            necessary, modify the [=start URL=] of an application.
+            necessary, modify the [=manifest/start URL=] of an application.
           </p>
           <p>
-            Additionally, developers MUST NOT use the [=start URL=] to include
+            Additionally, developers MUST NOT use the [=manifest/start URL=] to include
             information that uniquely identifies a user (e.g., "?user=123" or
             "/user/123/", or "https://user123.foo.bar").
           </p>
@@ -840,7 +840,7 @@
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">id</dfn></code> member is a <a>string</a> that represents
           the <dfn>identity</dfn> for the application. The [=identity=] takes
-          the form of a URL, which is same origin as the [=start URL=].
+          the form of a URL, which is same origin as the [=manifest/start URL=].
         </p>
         <p>
           The [=identity=] is used by user agents to uniquely identify the

--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
         application is launched.
       </p>
       <p>
-        A manifest has an associated <dfn data-export="">manifest URL</dfn>,
+        A manifest has an associated <dfn class="export">manifest URL</dfn>,
         which is the [[URL]] from which the <a>manifest</a> was fetched.
       </p>
       <p>


### PR DESCRIPTION
This change (choose at least one, delete ones that don't apply):

* Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

These are generally useful concepts relevant to the manifest spec but
not internal details. I am exporting them because they need to be linked
from the manifest-incubations spec.

Also ran tidy.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/1112.html" title="Last updated on Apr 10, 2024, 5:28 AM UTC (fed0454)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1112/9d8ad08...mgiuca:fed0454.html" title="Last updated on Apr 10, 2024, 5:28 AM UTC (fed0454)">Diff</a>