### PR TITLE
Rewrite privacy considerations on fingerprinting in start_url

### DIFF
--- a/index.html
+++ b/index.html
@@ -817,7 +817,7 @@
             This can be useful for analytics and possibly other customizations.
             However, it is also conceivable that developers could encode
             strings into the start_url that uniquely identify the user (e.g., a
-            server-assigned <abbr>UUID</abbr> such as `"?user=123"`,
+            server-assigned identifier, such as `"?user=123"`,
             `"/user/123/"`, or `"https://user123.foo.bar"`). This is
             fingerprinting/privacy sensitive information that the user might
             not be aware of.

--- a/index.html
+++ b/index.html
@@ -822,7 +822,7 @@
             fingerprinting/privacy sensitive information that the user might
             not be aware of.
           </p>
-          <p class="note">
+          <p class="note" title="Don't add identifiers to start URLs">
             It is bad practice for a developer to use the [=start URL=]
             to include information that uniquely identifies a user, as it would
             represent a fingerprint that is not cleared when the user clears

--- a/index.html
+++ b/index.html
@@ -823,7 +823,7 @@
             not be aware of.
           </p>
           <p class="note">
-            It would be irresponsible for a developer to use the [=start URL=]
+            It is bad practice for a developer to use the [=start URL=]
             to include information that uniquely identifies a user, as it would
             represent a fingerprint that is not cleared when the user clears
             site data. However, nothing in this specification can practically

--- a/index.html
+++ b/index.html
@@ -817,8 +817,17 @@
             This can be useful for analytics and possibly other customizations.
             However, it is also conceivable that developers could encode
             strings into the start_url that uniquely identify the user (e.g., a
-            server assigned <abbr>UUID</abbr>). This is fingerprinting/privacy
-            sensitive information that the user might not be aware of.
+            server-assigned <abbr>UUID</abbr> such as `"?user=123"`,
+            `"/user/123/"`, or `"https://user123.foo.bar"`). This is
+            fingerprinting/privacy sensitive information that the user might
+            not be aware of.
+          </p>
+          <p class="note">
+            It would be irresponsible for a developer to use the [=start URL=]
+            to include information that uniquely identifies a user, as it would
+            represent a fingerprint that is not cleared when the user clears
+            site data. However, nothing in this specification can practically
+            prevent developers from doing this.
           </p>
           <p>
             Given the above, it is RECOMMENDED that, upon installation, or any
@@ -826,9 +835,11 @@
             necessary, modify the [=start URL=] of an application.
           </p>
           <p>
-            Additionally, developers MUST NOT use the [=manifest/start URL=] to include
-            information that uniquely identifies a user (e.g., "?user=123" or
-            "/user/123/", or "https://user123.foo.bar").
+            A user agent MAY offer other protections against this form of
+            fingerprinting. For example, if a user clears data from an origin,
+            the user agent MAY offer to uninstall applications that are
+            [=manifest/within scope=] of that origin, thus removing the
+            potential fingerprint from the application's start URL.
           </p>
         </section>
       </section>


### PR DESCRIPTION
Closes #1113

This change (choose at least one, delete ones that don't apply):

* Adds new normative recommendations or optional items

(No implementation commitment required as it adds a MAY requirement.)

Commit message:

    Rewrite privacy considerations on fingerprinting in start_url.
    
    There is a "MUST NOT" requirement for developers about putting user data
    in the start_url. This is not enforceable, so rewriting the paragraph:
    
    1. Removed this requirement for developers.
    2. Added a non-normative note that tells developers it would be
       irresponsible to do this (but acknowledging that we can't practically
       prevent it).
    3. Added a MAY requirement for user agents to offer to uninstall apps
       associated with an origin when clearing site data.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/1114.html" title="Last updated on May 1, 2024, 6:22 AM UTC (3351bdc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1114/a791201...mgiuca:3351bdc.html" title="Last updated on May 1, 2024, 6:22 AM UTC (3351bdc)">Diff</a>