### PR TITLE
fix: dir's auto definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,8 +479,9 @@
             </p>
             <aside class="note">
               <p>
-                An actual direction value such as `rtl` or `ltr` is preferred
-                to relying on `auto`.
+                An actual direction value such as "[=text-direction/rtl=]" or
+                "[=text-direction/ltr=]" is preferred to relying on
+                "[=text-direction/auto=]".
               </p>
             </aside>
           </dd>

--- a/index.html
+++ b/index.html
@@ -473,7 +473,12 @@
             "<dfn data-dfn-for="text-direction">auto</dfn>" (default)
           </dt>
           <dd>
-            No explicit directionality.
+            <p>Direction determined from content.</p>
+            <aside class="note">
+              <p>
+                An actual direction value such as `rtl` or `ltr` is preferred to relying on `auto`.
+              </p>
+            </aside>
           </dd>
         </dl>
         <p>

--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
           </dt>
           <dd>
             <p>
-              Direction determined from content using the first-strong part of
+              Direction determined from content using <a data-cite="bidi#P2">Rule P2</a> of
               the [[BIDI]] algorithm.
             </p>
             <aside class="note">

--- a/index.html
+++ b/index.html
@@ -473,7 +473,7 @@
             "<dfn data-dfn-for="text-direction">auto</dfn>" (default)
           </dt>
           <dd>
-            <p>Direction determined from content.</p>
+            <p>Direction determined from content using the first-strong part of the [[BIDI]] algorithm.</p>
             <aside class="note">
               <p>
                 An actual direction value such as `rtl` or `ltr` is preferred to relying on `auto`.

--- a/index.html
+++ b/index.html
@@ -493,7 +493,7 @@
             </p>
             <aside class="note">
               <p>
-                An explicit direction value such as "[=text-direction/rtl=]" or
+[=text-direction/auto=] means that the directionality of each member is determined by its first strongly directional character (as per the <a data-cite="bidi#P2">Rule P2</a>). An explicit direction value such as "[=text-direction/rtl=]" or
                 "[=text-direction/ltr=]" is preferred to relying on the default of
                 "[=text-direction/auto=]".
               </p>

--- a/index.html
+++ b/index.html
@@ -473,10 +473,14 @@
             "<dfn data-dfn-for="text-direction">auto</dfn>" (default)
           </dt>
           <dd>
-            <p>Direction determined from content using the first-strong part of the [[BIDI]] algorithm.</p>
+            <p>
+              Direction determined from content using the first-strong part of
+              the [[BIDI]] algorithm.
+            </p>
             <aside class="note">
               <p>
-                An actual direction value such as `rtl` or `ltr` is preferred to relying on `auto`.
+                An actual direction value such as `rtl` or `ltr` is preferred
+                to relying on `auto`.
               </p>
             </aside>
           </dd>

--- a/index.html
+++ b/index.html
@@ -494,7 +494,7 @@
             <aside class="note">
               <p>
                 An explicit direction value such as "[=text-direction/rtl=]" or
-                "[=text-direction/ltr=]" is preferred to relying on
+                "[=text-direction/ltr=]" is preferred to relying on the default of
                 "[=text-direction/auto=]".
               </p>
             </aside>

--- a/index.html
+++ b/index.html
@@ -488,14 +488,17 @@
           </dt>
           <dd>
             <p>
-              Direction determined from content using <a data-cite="bidi#P2">Rule P2</a> of
-              the [[BIDI]] algorithm.
+              Direction determined from content using <a data-cite=
+              "bidi#P2">Rule P2</a> of the [[BIDI]] algorithm.
             </p>
             <aside class="note">
               <p>
-[=text-direction/auto=] means that the directionality of each member is determined by its first strongly directional character (as per the <a data-cite="bidi#P2">Rule P2</a>). An explicit direction value such as "[=text-direction/rtl=]" or
-                "[=text-direction/ltr=]" is preferred to relying on the default of
-                "[=text-direction/auto=]".
+                [=text-direction/auto=] means that the directionality of each
+                member is determined by its first strongly directional
+                character (as per the <a data-cite="bidi#P2">Rule P2</a>). An
+                explicit direction value such as "[=text-direction/rtl=]" or
+                "[=text-direction/ltr=]" is preferred to relying on the default
+                of "[=text-direction/auto=]".
               </p>
             </aside>
           </dd>

--- a/index.html
+++ b/index.html
@@ -479,7 +479,7 @@
             </p>
             <aside class="note">
               <p>
-                An actual direction value such as "[=text-direction/rtl=]" or
+                An explicit direction value such as "[=text-direction/rtl=]" or
                 "[=text-direction/ltr=]" is preferred to relying on
                 "[=text-direction/auto=]".
               </p>


### PR DESCRIPTION
Closes #1079

This change (choose at least one, delete ones that don't apply):

* Breaks existing normative behavior (please add label "breaking")
* Adds new normative requirements
* Adds new normative recommendations or optional items
* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)
* Is a "chore" (metadata, formatting, fixing warnings, etc).

Implementation commitment (delete if not making normative changes):

* [ ] WebKit (https://bugs.webkit.org)
* [ ] Chromium (https://bugs.chromium.org/)
* [ ] Gecko (http://bugzilla.mozilla.org)

If change is normative, and it adds or changes a member:

* [ ] [updated JSON schema](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/web-manifest.json)

Commit message:

(Fill in. If making normative changes, describe exactly what the behavioral
difference will be.)

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1118.html" title="Last updated on Jun 6, 2024, 11:13 PM UTC (c9f3254)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1118/2f54efe...c9f3254.html" title="Last updated on Jun 6, 2024, 11:13 PM UTC (c9f3254)">Diff</a>