### PR TITLE
Processing steps for id now removes the fragment

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,9 +858,9 @@
           application, it SHOULD treat that manifest as a description of a
           distinct application, even if it is served from the same URL as that
           of another application. When the user agent sees a manifest where
-          |manifest|["id"] is [=url/equal=] (OPTIONAL: with
-          [=URL/equals/exclude fragments=] set to true) to the [=identity=] of
-          an already-installed application, it SHOULD be used as a signal that
+          |manifest|["id"] is [=url/equal=] (with [=URL/equals/exclude
+          fragments=] OPTIONALLY set to true) to the [=identity=] of an
+          already-installed application, it SHOULD be used as a signal that
           this manifest is a replacement for the already-installed
           application's manifest, and not a distinct application, even if it is
           served from a different URL than the one seen previously.

--- a/index.html
+++ b/index.html
@@ -626,8 +626,7 @@
           </li>
           <li>If |scope| is failure, return.
           </li>
-          <li>From |scope|, remove the [=url/query=] and [=url/fragment=]
-          components.
+          <li>Set |scope|'s [=URL/query=] and [=URL/fragment=] to null.
           </li>
           <li>If |manifest|["start_url"] is not [=URL/within scope=] of
           |scope|, return.

--- a/index.html
+++ b/index.html
@@ -865,6 +865,19 @@
           a distinct application, even if it is served from a different URL
           than the one seen previously.
         </p>
+        <p class="note" title="Exclude fragments for good measure">
+          Since the [=process the id member|processing algorithm=] removes the
+          [=URL/fragment=] from the <code>[=id=]</code> member, it is not
+          strictly necessary to [=URL/equals/exclude fragments=] when checking
+          for a matching application. However, a database of installed
+          applications can contain old or erroneous data. In particular, old
+          versions of this spec (and therefore possibly old versions of user
+          agents) did not remove the [=URL/fragment=] from the [=URL=] at parse
+          time, and relied only on [=URL/equals/exclude fragments|excluding
+          fragments=] during comparisons. Therefore, we ask that user agents
+          continue to [=URL/equals/exclude fragments=] when comparing against
+          their existing app database.
+        </p>
         <p class="note">
           The [=identity=] can be used by a service that collects lists of web
           applications to uniquely identify applications.

--- a/index.html
+++ b/index.html
@@ -879,7 +879,7 @@
           application's manifest, and not a distinct application, even if it is
           served from a different URL than the one seen previously.
         </p>
-        <p class="note" title="Excluding fragments is best practice">
+        <aside class="note" title="Excluding fragments is best practice">
           Since the [=process the id member|processing algorithm=] removes the
           [=URL/fragment=] from the <code>[=manifest/id=]</code> member, it is
           not strictly necessary to [=URL/equals/exclude fragments=] when
@@ -891,7 +891,7 @@
           the <code>[=manifest/id=]</code>. Therefore, it is best practice for
           user agents to [=URL/equals/exclude fragments=] even when comparing
           two [=URLs=] that ought not to have fragments.
-        </p>
+        </aside>
         <p class="note">
           The [=identity=] can be used by a service that collects lists of web
           applications to uniquely identify applications.

--- a/index.html
+++ b/index.html
@@ -874,7 +874,7 @@
           from the [=URL=] at parse time, and relied only on
           [=URL/equals/exclude fragments|excluding fragments=] during
           comparisons, there may be historical app data with [=URL/fragments=]
-          in the <code>[=id=]</code>. Therefore, it is best practice for user
+          in the <code>[=manifest/id=]</code>. Therefore, it is best practice for user
           agents to [=URL/equals/exclude fragments=] even when comparing two
           [=URLs=] that should not have any fragments.
         </p>

--- a/index.html
+++ b/index.html
@@ -867,7 +867,7 @@
         </p>
         <p class="note" title="Exclude fragments for good measure">
           Since the [=process the id member|processing algorithm=] removes the
-          [=URL/fragment=] from the <code>[=id=]</code> member, it is not
+          [=URL/fragment=] from the <code>[=manifest/id=]</code> member, it is not
           strictly necessary to [=URL/equals/exclude fragments=] when checking
           for a matching application. However, since old versions of this spec
           (and, possibly, old user agents) did not remove the [=URL/fragment=]

--- a/index.html
+++ b/index.html
@@ -895,6 +895,8 @@
           <li>If |id| is not [=same origin=] as |manifest|["start_url"],
           return.
           </li>
+          <li>Set |id|'s [=URL/fragment=] to null.
+          </li>
           <li>Set |manifest|["id"] to |id|.
           </li>
         </ol>
@@ -934,7 +936,7 @@
                 "https://example.com/my-app/#here"
               </td>
               <td>
-                "https://example.com/my-app/#here"
+                "https://example.com/my-app/"
               </td>
             </tr>
             <tr>
@@ -962,6 +964,28 @@
             <tr>
               <td>
                 "foo"
+              </td>
+              <td>
+                "https://example.com/my-app/start"
+              </td>
+              <td>
+                "https://example.com/foo"
+              </td>
+            </tr>
+            <tr>
+              <td>
+                "foo?x=y"
+              </td>
+              <td>
+                "https://example.com/my-app/start"
+              </td>
+              <td>
+                "https://example.com/foo?x=y"
+              </td>
+            </tr>
+            <tr>
+              <td>
+                "foo#heading"
               </td>
               <td>
                 "https://example.com/my-app/start"

--- a/index.html
+++ b/index.html
@@ -1321,8 +1321,7 @@
             </li>
             <li>If the [=document=]'s [=document|processed manifest=] is not
             null, and [=document=]'s [=document|processed manifest=]'s id is
-            not [=URL/equal=] with [=URL serializer/exclude fragment|exclude
-            fragment true=] to |manifest|["id"], return.
+            not [=URL/equal=] to |manifest|["id"], return.
             </li>
             <li>[=Process the `scope` member=] passing |json|, |manifest|, and
             |manifest URL|.

--- a/index.html
+++ b/index.html
@@ -858,12 +858,12 @@
           application, it SHOULD treat that manifest as a description of a
           distinct application, even if it is served from the same URL as that
           of another application. When the user agent sees a manifest where
-          |manifest|["id"] is [=url/equal=] with [=URL serializer/exclude
-          fragment|exclude fragment true=] to the [=identity=] of an
-          already-installed application, it SHOULD be used as a signal that
-          this manifest is a replacement for the already-installed
-          application's manifest, and not a distinct application, even if it is
-          served from a different URL than the one seen previously.
+          |manifest|["id"] is [=url/equal=] with [=URL/equals/exclude
+          fragments=] set to true to the [=identity=] of an already-installed
+          application, it SHOULD be used as a signal that this manifest is a
+          replacement for the already-installed application's manifest, and not
+          a distinct application, even if it is served from a different URL
+          than the one seen previously.
         </p>
         <p class="note">
           The [=identity=] can be used by a service that collects lists of web

--- a/index.html
+++ b/index.html
@@ -865,7 +865,7 @@
           application's manifest, and not a distinct application, even if it is
           served from a different URL than the one seen previously.
         </p>
-        <p class="note" title="Exclude fragments for good measure">
+        <p class="note" title="Excluding fragments is best practice">
           Since the [=process the id member|processing algorithm=] removes the
           [=URL/fragment=] from the <code>[=manifest/id=]</code> member, it is
           not strictly necessary to [=URL/equals/exclude fragments=] when
@@ -873,10 +873,10 @@
           this spec (and, possibly, old user agents) did not remove the
           [=URL/fragment=] from the [=URL=] at parse time, and relied only on
           [=URL/equals/exclude fragments|excluding fragments=] during
-          comparisons, there may be historical app data with [=URL/fragments=]
-          in the <code>[=manifest/id=]</code>. Therefore, it is best practice
-          for user agents to [=URL/equals/exclude fragments=] even when
-          comparing two [=URLs=] that should not have any fragments.
+          comparisons, historical app data could contain [=URL/fragments=] in
+          the <code>[=manifest/id=]</code>. Therefore, it is best practice for
+          user agents to [=URL/equals/exclude fragments=] even when comparing
+          two [=URLs=] that ought not to have fragments.
         </p>
         <p class="note">
           The [=identity=] can be used by a service that collects lists of web

--- a/index.html
+++ b/index.html
@@ -867,16 +867,16 @@
         </p>
         <p class="note" title="Exclude fragments for good measure">
           Since the [=process the id member|processing algorithm=] removes the
-          [=URL/fragment=] from the <code>[=manifest/id=]</code> member, it is not
-          strictly necessary to [=URL/equals/exclude fragments=] when checking
-          for a matching application. However, since old versions of this spec
-          (and, possibly, old user agents) did not remove the [=URL/fragment=]
-          from the [=URL=] at parse time, and relied only on
+          [=URL/fragment=] from the <code>[=manifest/id=]</code> member, it is
+          not strictly necessary to [=URL/equals/exclude fragments=] when
+          checking for a matching application. However, since old versions of
+          this spec (and, possibly, old user agents) did not remove the
+          [=URL/fragment=] from the [=URL=] at parse time, and relied only on
           [=URL/equals/exclude fragments|excluding fragments=] during
           comparisons, there may be historical app data with [=URL/fragments=]
-          in the <code>[=manifest/id=]</code>. Therefore, it is best practice for user
-          agents to [=URL/equals/exclude fragments=] even when comparing two
-          [=URLs=] that should not have any fragments.
+          in the <code>[=manifest/id=]</code>. Therefore, it is best practice
+          for user agents to [=URL/equals/exclude fragments=] even when
+          comparing two [=URLs=] that should not have any fragments.
         </p>
         <p class="note">
           The [=identity=] can be used by a service that collects lists of web

--- a/index.html
+++ b/index.html
@@ -858,25 +858,25 @@
           application, it SHOULD treat that manifest as a description of a
           distinct application, even if it is served from the same URL as that
           of another application. When the user agent sees a manifest where
-          |manifest|["id"] is [=url/equal=] with [=URL/equals/exclude
-          fragments=] set to true to the [=identity=] of an already-installed
-          application, it SHOULD be used as a signal that this manifest is a
-          replacement for the already-installed application's manifest, and not
-          a distinct application, even if it is served from a different URL
-          than the one seen previously.
+          |manifest|["id"] is [=url/equal=] (OPTIONAL: with
+          [=URL/equals/exclude fragments=] set to true) to the [=identity=] of
+          an already-installed application, it SHOULD be used as a signal that
+          this manifest is a replacement for the already-installed
+          application's manifest, and not a distinct application, even if it is
+          served from a different URL than the one seen previously.
         </p>
         <p class="note" title="Exclude fragments for good measure">
           Since the [=process the id member|processing algorithm=] removes the
           [=URL/fragment=] from the <code>[=id=]</code> member, it is not
           strictly necessary to [=URL/equals/exclude fragments=] when checking
-          for a matching application. However, a database of installed
-          applications can contain old or erroneous data. In particular, old
-          versions of this spec (and therefore possibly old versions of user
-          agents) did not remove the [=URL/fragment=] from the [=URL=] at parse
-          time, and relied only on [=URL/equals/exclude fragments|excluding
-          fragments=] during comparisons. Therefore, we ask that user agents
-          continue to [=URL/equals/exclude fragments=] when comparing against
-          their existing app database.
+          for a matching application. However, since old versions of this spec
+          (and, possibly, old user agents) did not remove the [=URL/fragment=]
+          from the [=URL=] at parse time, and relied only on
+          [=URL/equals/exclude fragments|excluding fragments=] during
+          comparisons, there may be historical app data with [=URL/fragments=]
+          in the <code>[=id=]</code>. Therefore, it is best practice for user
+          agents to [=URL/equals/exclude fragments=] even when comparing two
+          [=URLs=] that should not have any fragments.
         </p>
         <p class="note">
           The [=identity=] can be used by a service that collects lists of web


### PR DESCRIPTION
Closes #1121

This change (choose at least one, delete ones that don't apply):

* Adds new normative recommendations or optional items

[Note: This technically changes normative behaviour, but does not break implementations. Any implementation that keeps the fragment and strips it out when comparing ids will behave the same as this. The new behaviour just encourages implementations to keep their local data model clean.]

Commit message:

The canonical id no longer includes the fragment. This was already effectively true (as all comparisons would exclude fragments), but now it makes it true in the processed manifest's canonical id.

Removed or made optional the exclude fragments in the comparisons. Added a lengthy note as to why user agents may still wish to exclude fragments when comparing against potentially old database entries.

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest/pull/1122.html" title="Last updated on Jun 6, 2024, 10:45 PM UTC (86c8d94)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1122/4b97432...mgiuca:86c8d94.html" title="Last updated on Jun 6, 2024, 10:45 PM UTC (86c8d94)">Diff</a>