### PR TITLE
Editorial: cite UAX9 not BIDI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1476,7 +1476,7 @@
               user's device via a sync service). But the above recommendations
               ask the user agent to verify that, when an application scope is
               on origin A and the manifest is on a different origin B, there is
-              a UAX9rectional relationship between the two origins.
+              a bidirectional relationship between the two origins.
             </p>
             <p>
               The first check ensures that at least some page on origin A links

--- a/index.html
+++ b/index.html
@@ -489,13 +489,13 @@
           <dd>
             <p>
               Direction determined from content using <a data-cite=
-              "bidi#P2">Rule P2</a> of the [[BIDI]] algorithm.
+              "UAX9#P2">Rule P2</a> of the [[UAX9]] algorithm.
             </p>
             <aside class="note">
               <p>
                 [=text-direction/auto=] means that the directionality of each
                 member is determined by its first strongly directional
-                character (as per the <a data-cite="bidi#P2">Rule P2</a>). An
+                character (as per the <a data-cite="UAX9#P2">Rule P2</a>). An
                 explicit direction value such as "[=text-direction/rtl=]" or
                 "[=text-direction/ltr=]" is preferred to relying on the default
                 of "[=text-direction/auto=]".
@@ -514,14 +514,14 @@
         </p>
         <ol class="algorithm">
           <li>If the <a>base direction</a> is [=text-direction/ltr=] or
-          [=text-direction/rtl=], override <a data-cite="bidi#P3">Rule P3</a>
-          of [[BIDI]], setting the paragraph embedding level to 0 if the
+          [=text-direction/rtl=], override <a data-cite="UAX9#P3">Rule P3</a>
+          of [[UAX9]], setting the paragraph embedding level to 0 if the
           <a>base direction</a> is [=text-direction/ltr=], or 1 if the <a>base
           direction</a> is [=text-direction/rtl=].
           </li>
           <li>Otherwise the <a>base direction</a> is "[=text-direction/auto=]",
           in which case determine the text's direction by applying
-            <a data-cite="bidi#P1">Rule P1</a> of [[BIDI]].
+            <a data-cite="UAX9#P1">Rule P1</a> of [[UAX9]].
           </li>
         </ol>
         <p>
@@ -1476,7 +1476,7 @@
               user's device via a sync service). But the above recommendations
               ask the user agent to verify that, when an application scope is
               on origin A and the manifest is on a different origin B, there is
-              a bidirectional relationship between the two origins.
+              a UAX9rectional relationship between the two origins.
             </p>
             <p>
               The first check ensures that at least some page on origin A links


### PR DESCRIPTION
See #1081 (doesn't close it)

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

@aphillips suggested we switch to citing UAX9 instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1131.html" title="Last updated on Jun 7, 2024, 10:15 AM UTC (3332c44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1131/55e6818...3332c44.html" title="Last updated on Jun 7, 2024, 10:15 AM UTC (3332c44)">Diff</a>