### PR TITLE
Editorial: fix `lang` description

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,10 +547,14 @@
         </h3>
         <p>
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
-          "manifest">lang</dfn></code> member is a <a>string</a> in the form of
-          a <a>language tag</a> that specifies the primary language for the
-          values of the manifest's <a>localizable members</a> (as knowing the
-          language can also help with directionality).
+          "manifest">lang</dfn></code> member is a [=string=] in the form of a
+          [=language tag=] that specifies the language for the values of the
+          manifest's [=localizable members=].
+        </p>
+        <p class="note">
+        Specifying the language improves the user experience by helping
+        user agents select the most appropriate processing or resources,
+        such as fonts, styling, hyphenation, or text-to-speech voices for accessibility.
         </p>
         <p>
           A <dfn>language tag</dfn> is a <a>string</a> that matches the


### PR DESCRIPTION
Closes #1082

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

Editorial: fix `lang` description

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1133.html" title="Last updated on Jun 12, 2024, 4:15 PM UTC (e40c10c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1133/3c58e39...e40c10c.html" title="Last updated on Jun 12, 2024, 4:15 PM UTC (e40c10c)">Diff</a>