### PR TITLE
Editorial: fix language tag description (#1083)

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,18 +557,14 @@
         such as fonts, styling, hyphenation, or text-to-speech voices for accessibility.
         </p>
         <p>
-          A <dfn>language tag</dfn> is a <a>string</a> that matches the
-          production of a `Language-Tag` defined in the [[BCP47]]
-          specifications (see the <a href=
-          "https://www.iana.org/assignments/language-subtag-registry">IANA
-          Language Subtag Registry</a> for an authoritative list of possible
-          values). That is, a language range is composed of one or more
-          <dfn>subtags</dfn> that are delimited by a U+002D HYPHEN-MINUS ("-").
-          For example, the '`en-AU`' language range represents English as
-          spoken in Australia, and '`fr-CA`' represents French as spoken in
-          Canada. Language tags that meet the validity criteria of [[RFC5646]]
-          section 2.2.9 that can be verified without reference to the IANA
-          Language Subtag Registry are considered structurally valid.
+          A <dfn>language tag</dfn> is a [=string=] that matches the production
+          of a well-formed `Language-Tag` defined in [[BCP47]].
+        </p>
+        <p class="note">
+          Language tags are case-insensitive. Examples of language tags include
+          '`fr`' (French), '`en-AU`' (English as spoken in Australia), or
+          '`zh-Hans-CN`' (Chinese as written in the Simplified Han script as
+          spoken in China).
         </p>
         <p>
           To <dfn>process the `lang` member</dfn>, given [=ordered map=]


### PR DESCRIPTION
Closes #1083

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

Editorial: fix language tag description (#1083)

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1134.html" title="Last updated on Jun 12, 2024, 4:17 PM UTC (a99ea1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1134/7317a85...a99ea1e.html" title="Last updated on Jun 12, 2024, 4:17 PM UTC (a99ea1e)">Diff</a>