### PR TITLE
clarify the definition of "navigation scope", "applied", and off-scope theming

### DIFF
--- a/index.html
+++ b/index.html
@@ -1083,7 +1083,7 @@
           [=application context=]'s [=manifest=] includes a [^meta^] element
           whose [^meta/name^] attribute is "[^meta/name/theme-color^]".
           However, the user agent SHOULD NOT override the [=default theme
-          color=] via an [^meta^] element whose [^meta/name^] attribute is
+          color=] via a [^meta^] element whose [^meta/name^] attribute is
           "theme-color" for [=documents=]' [=Document/URL=] are not [=URL/within scope=], since the
           application has no control over these documents.
         </p>

--- a/index.html
+++ b/index.html
@@ -1079,7 +1079,7 @@
           member as the [=default theme color=], then that color serves as the
           [=theme color=] for all [=browsing contexts=] to which the manifest is
           [=applied=]. However, the user agent MAY override the [=default theme
-          color=] if a document whose URL is [=URL/within scope=] of the
+          color=] if a [=document=] whose [=Document/URL=] is [=URL/within scope=] of the
           [=application context=]'s [=manifest=] includes a [^meta^] element
           whose [^meta/name^] attribute is "[^meta/name/theme-color^]".
           However, the user agent SHOULD NOT override the [=default theme

--- a/index.html
+++ b/index.html
@@ -1084,7 +1084,7 @@
           whose [^meta/name^] attribute is "[^meta/name/theme-color^]".
           However, the user agent SHOULD NOT override the [=default theme
           color=] via an [^meta^] element whose [^meta/name^] attribute is
-          "theme-color" for documents that are not [=within scope=], since the
+          "theme-color" for documents' [=Document/URL=] are not [=URL/within scope=], since the
           application has no control over these documents.
         </p>
         <p data-cite="CSS-COLOR-4">

--- a/index.html
+++ b/index.html
@@ -1074,12 +1074,16 @@
         </p>
         <p>
           If the user agent honors the value of the [=manifest/theme_color=]
-          member as the <a>default theme color</a>, then that color serves as
-          the <a>theme color</a> for all browsing contexts to which the
-          manifest is <a>applied</a>. However, a document may override the
-          <a>default theme color</a> through the inclusion of a valid [[HTML]]
-          [^meta^] element whose [^meta/name^] attribute value is
-          `"theme-color"`.
+          member as the [=default theme color=], then that color serves as the
+          [=theme color=] for all browsing contexts to which the manifest is
+          [=applied=]. However, the user agent MAY override the [=default theme
+          color=] if a document whose URL is [=within scope=] of the
+          [=application context=]'s [=manifest=] includes a [^meta^] element
+          whose [^meta/name^] attribute is "[^meta/name/theme-color^]".
+          However, the user agent SHOULD NOT override the [=default theme
+          color=] via an [^meta^] element whose [^meta/name^] attribute is
+          "theme-color" for documents that are not [=within scope=], since the
+          application has no control over these documents.
         </p>
         <p data-cite="CSS-COLOR-4">
           The user agent MAY ignore the <a>theme color</a>'s [=alpha
@@ -1779,12 +1783,23 @@
             Applying the manifest
           </h3>
           <p>
-            A [=Document/processed manifest=] is <dfn data-export=""
-            data-local-lt="apply|applying">applied</dfn> to a <a>top-level
-            browsing context</a>, meaning that the members of the
-            [=Document/processed manifest=] are affecting the presentation or
-            behavior of a browsing context.
+            A [=Document/processed manifest=] is <dfn data-lt=
+            "apply|applying">applied</dfn> to a [=top-level browsing context=],
+            meaning that the members of the <a>manifest</a> are affecting the
+            presentation and/or behavior of the browsing context. Whenever a
+            [=top-level browsing context=] is created, the user agent MAY
+            [=apply=] a manifest to it before [=navigate|navigation=] begins.
           </p>
+          <aside class="note">
+            Whether to [=apply=] a manifest, and which manifest to apply, is at
+            the discretion of the user agent, based on the user's actions. For
+            example, if the user launched an application from the system menu
+            or from a [=launching a shortcut|shortcut=], the user agent might
+            create a new [=top-level browsing context=] with that application's
+            [=manifest=] [=applied=], but it might not do so if the user simply
+            clicked a bookmark to a URL within the application's [=navigation
+            scope=].
+          </aside>
           <p>
             A <a>top-level browsing context</a> that has a manifest applied to
             it is referred to as an <dfn data-export="">application
@@ -1806,11 +1821,6 @@
               changed it when the application was <a>installed</a>.
             </p>
           </aside>
-          <p>
-            The appropriate time to <a>apply</a> a manifest is when the
-            <a>application context</a> is created and before
-            [=navigate|navigation=] to the <a>start URL</a> begins.
-          </p>
         </section>
         <section id="updating">
           <h3>
@@ -2796,10 +2806,10 @@
       </h2>
       <p>
         The <dfn data-dfn-for="manifest" data-lt="navigation scope"
-        data-export="">navigation scope of a manifest</dfn> is the "scope" item
-        of a [=Document/processed manifest=]. The navigation scope restricts
-        the set of URLs to which an [=application context=] can be
-        [=navigated=] while the manifest is [=applied=].
+        data-export="">navigation scope of a manifest</dfn> is the
+        "<a>scope</a>" member of a [=Document/processed manifest=]. The
+        navigation scope governs the set of URLs to which an [=application
+        context=] can be [=navigated=] while the manifest is [=applied=].
       </p>
       <div class="note">
         <p>

--- a/index.html
+++ b/index.html
@@ -2586,7 +2586,7 @@
       <p>
         The <dfn data-dfn-for="manifest" data-lt="navigation scope"
         data-export="">navigation scope of a manifest</dfn> is the
-        "<a>scope</a>" member of a [=Document/processed manifest=]. The
+        "[=manifest/scope=]" member of a [=Document/processed manifest=]. The
         navigation scope governs the set of URLs to which an [=application
         context=] can be [=navigated=] while the manifest is [=applied=].
       </p>

--- a/index.html
+++ b/index.html
@@ -1084,7 +1084,7 @@
           whose [^meta/name^] attribute is "[^meta/name/theme-color^]".
           However, the user agent SHOULD NOT override the [=default theme
           color=] via an [^meta^] element whose [^meta/name^] attribute is
-          "theme-color" for documents' [=Document/URL=] are not [=URL/within scope=], since the
+          "theme-color" for [=documents=]' [=Document/URL=] are not [=URL/within scope=], since the
           application has no control over these documents.
         </p>
         <p data-cite="CSS-COLOR-4">

--- a/index.html
+++ b/index.html
@@ -2587,7 +2587,7 @@
         The <dfn data-dfn-for="manifest" data-lt="navigation scope"
         data-export="">navigation scope of a manifest</dfn> is the
         "[=manifest/scope=]" member of a [=Document/processed manifest=]. The
-        navigation scope governs the set of URLs to which an [=application
+        navigation scope is the URLs to which an [=application
         context=] can be [=navigated=] while the manifest is [=applied=].
       </p>
       <div class="note">

--- a/index.html
+++ b/index.html
@@ -1077,7 +1077,7 @@
         <p>
           If the user agent honors the value of the [=manifest/theme_color=]
           member as the [=default theme color=], then that color serves as the
-          [=theme color=] for all browsing contexts to which the manifest is
+          [=theme color=] for all [=browsing contexts=] to which the manifest is
           [=applied=]. However, the user agent MAY override the [=default theme
           color=] if a document whose URL is [=within scope=] of the
           [=application context=]'s [=manifest=] includes a [^meta^] element

--- a/index.html
+++ b/index.html
@@ -1709,7 +1709,7 @@
           <p>
             A [=Document/processed manifest=] is <dfn data-lt=
             "apply|applying">applied</dfn> to a [=top-level browsing context=],
-            meaning that the members of the <a>manifest</a> are affecting the
+            meaning that the members of the [=manifest=] are affecting the
             presentation and/or behavior of the browsing context. Whenever a
             [=top-level browsing context=] is created, the user agent MAY
             [=apply=] a manifest to it before [=navigate|navigation=] begins.

--- a/index.html
+++ b/index.html
@@ -1079,7 +1079,7 @@
           member as the [=default theme color=], then that color serves as the
           [=theme color=] for all [=browsing contexts=] to which the manifest is
           [=applied=]. However, the user agent MAY override the [=default theme
-          color=] if a document whose URL is [=within scope=] of the
+          color=] if a document whose URL is [=URL/within scope=] of the
           [=application context=]'s [=manifest=] includes a [^meta^] element
           whose [^meta/name^] attribute is "[^meta/name/theme-color^]".
           However, the user agent SHOULD NOT override the [=default theme

--- a/index.html
+++ b/index.html
@@ -1077,15 +1077,16 @@
         <p>
           If the user agent honors the value of the [=manifest/theme_color=]
           member as the [=default theme color=], then that color serves as the
-          [=theme color=] for all [=browsing contexts=] to which the manifest is
-          [=applied=]. However, the user agent MAY override the [=default theme
-          color=] if a [=document=] whose [=Document/URL=] is [=URL/within scope=] of the
-          [=application context=]'s [=manifest=] includes a [^meta^] element
-          whose [^meta/name^] attribute is "[^meta/name/theme-color^]".
-          However, the user agent SHOULD NOT override the [=default theme
-          color=] via a [^meta^] element whose [^meta/name^] attribute is
-          "theme-color" for [=documents=]' [=Document/URL=] are not [=URL/within scope=], since the
-          application has no control over these documents.
+          [=theme color=] for all [=browsing contexts=] to which the manifest
+          is [=applied=]. However, the user agent MAY override the [=default
+          theme color=] if a [=document=] whose [=Document/URL=] is
+          [=URL/within scope=] of the [=application context=]'s [=manifest=]
+          includes a [^meta^] element whose [^meta/name^] attribute is
+          "[^meta/name/theme-color^]". However, the user agent SHOULD NOT
+          override the [=default theme color=] via a [^meta^] element whose
+          [^meta/name^] attribute is "theme-color" for [=documents=]'
+          [=Document/URL=] are not [=URL/within scope=], since the application
+          has no control over these documents.
         </p>
         <p data-cite="CSS-COLOR-4">
           The user agent MAY ignore the <a>theme color</a>'s [=alpha
@@ -1721,8 +1722,8 @@
             or from a [=launching a shortcut|shortcut=], the user agent might
             create a new [=top-level browsing context=] with that application's
             [=manifest=] [=applied=], but it might not do so if the user simply
-            clicked a bookmark to a URL within the application's [=navigation
-            scope=].
+            clicked a bookmark to a URL within the application's
+            [=manifest/navigation scope=].
           </aside>
           <p>
             A <a>top-level browsing context</a> that has a manifest applied to
@@ -2587,8 +2588,8 @@
         The <dfn data-dfn-for="manifest" data-lt="navigation scope"
         data-export="">navigation scope of a manifest</dfn> is the
         "[=manifest/scope=]" member of a [=Document/processed manifest=]. The
-        navigation scope is the URLs to which an [=application
-        context=] can be [=navigated=] while the manifest is [=applied=].
+        navigation scope is the URLs to which an [=application context=] can be
+        [=navigated=] while the manifest is [=applied=].
       </p>
       <div class="note">
         <p>


### PR DESCRIPTION
Closes #880

This is @mgiuca original commit.  

Closes #755.

This change (choose one):

* [ ] Breaks existing normative behavior (please add label "breaking")
* [ ] Adds new normative requirements
* [X] Adds new normative recommendations or optional items
* [ ] Makes only editorial changes (only changes informative sections, or
  changes normative sections without changing behavior)
* [ ] Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

This further clarifies that a manifest is allowed to apply to URLs that
are not within its scope (that this was not clear was a left-over
mistake from #701), and that a document within scope is allowed to
override the theme color. Adds a new recommendation that an out of scope
document not be allowed to override the theme color.

This introduces new normative recommendations, only insofar as they were
already commonly understood, to my knowledge.

Navigation scope: No longer defined in terms of the URLs that a manifest
is allowed to apply to (since a manifest may apply to any URL). Rather,
it's just a set of URLs; the other normative requirements around
navigation scope define what it means.

Applied: Clarified that it is the user agent's discretion whether or not
to apply a manifest when a top-level browsing context is created, with
examples of when you would and would not apply it (previously, there was
simply no text around when a manifest should be applied).

Theme color: Fixes a "MAY" requirement imposed on the document
(requirements can only be imposed on user agents). Clarifies this
recommendation as only applying to in-scope documents, and adds a
recommendation against applying document theme for out-of-scope
documents.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1151.html" title="Last updated on Nov 7, 2024, 11:39 AM UTC (bc03acf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1151/40cf2c7...bc03acf.html" title="Last updated on Nov 7, 2024, 11:39 AM UTC (bc03acf)">Diff</a>