### PR TITLE
Link incubations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ the [Web Applications Working Group](https://www.w3.org/2019/webapps/).
 ## Useful links
 * [Explainer](https://github.com/w3c/manifest/blob/gh-pages/explainer.md)
 * [The Web Application Manifest specification](https://www.w3.org/TR/appmanifest/)
+* [Manifest incubations](https://github.com/WICG/manifest-incubations)
 * [App Information supplement](https://github.com/w3c/manifest-app-info)
 * [Use cases and requirements](https://w3c-webmob.github.io/installable-webapps/)
 * [The Web Applications WG homepage](https://www.w3.org/2019/webapps/)

--- a/index.html
+++ b/index.html
@@ -3227,11 +3227,10 @@
             for a second user agent on a different platform to make use of that
             member, even if no other user agent has expressed interest right
             now). If so, we ask authors to design the API in a vendor-neutral
-            way, and propose it as a standard (see [[[#incubations]]]). If the
-            new member is truly proprietary (i.e. will only ever make sense in
-            the context of a proprietary ecosystem), use this process, and
-            prefix it with the short name of that proprietary ecosystem to
-            avoid name collisions.
+            way, and propose it as a standard. If the new member is truly
+            proprietary (i.e. will only ever make sense in the context of a
+            proprietary ecosystem), use this process, and prefix it with the
+            short name of that proprietary ecosystem to avoid name collisions.
           </p>
           <p>
             Do not use vendor prefixes that you intend to later remove once it

--- a/index.html
+++ b/index.html
@@ -3265,45 +3265,6 @@
       </section>
     </section>
     <section class="appendix informative">
-      <h2 id="incubations">
-        Incubations
-      </h2>
-      <p>
-        Extensions to this specification are being incubated in parallel by the
-        Web Community, some of which are shipping in multiple browsers. If two
-        or more browser engines end up supporting an incubated feature, then
-        those features will become part of this specification in the future -
-        allowing them to become a standard the Web Platform:
-      </p>
-      <dl>
-        <dt>
-          `BeforeInstallPrompt` and `window.onappinstalled` event
-        </dt>
-        <dd>
-          The `BeforeInstallPrompt` event and `window.onappinstalled` event
-          were originally part of this specification. However, they were
-          <a href="https://github.com/w3c/manifest/pull/836">removed from the
-          specification</a> because they did not have support from two or more
-          implementers. You can now find them in the <a href=
-          "https://github.com/WICG/manifest-incubations">`BeforeInstallPrompt`
-          event and `window.onappinstalled` repository</a> at the <a href=
-          "https://wicg.io"><abbr title=
-          "Web Incubator Community Group">WICG</abbr></a>.
-        </dd>
-        <dt>
-          `share_target` member
-        </dt>
-        <dd>
-          The `share_target` member registers a web application as "target" for
-          share actions (e.g., for sharing a text, a URL, or a file). The
-          `share_target` member is part of the <a href=
-          "https://wicg.github.io/web-share-target/">Web Share Target</a>
-          specification, being incubated at the <a href=
-          "https://wicg.io">WICG</a>.
-        </dd>
-      </dl>
-    </section>
-    <section class="appendix informative">
       <h2>
         Application Information
       </h2>


### PR DESCRIPTION
This PR links the incubations repository instead of enumerating the incubated extensions. It's hard to keep that in sync, and the manifest incubations repository has way more incubations than just BIP. The share target incubation is also linked in manifest incubations.

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

Editorial: Link incubations

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1153.html" title="Last updated on Mar 20, 2025, 2:15 PM UTC (081d45a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1153/5088e7b...081d45a.html" title="Last updated on Mar 20, 2025, 2:15 PM UTC (081d45a)">Diff</a>