### PR TITLE
Clarify how manifest image resources are fetched

### DIFF
--- a/index.html
+++ b/index.html
@@ -1611,8 +1611,8 @@
             The steps for <dfn data-export="" data-local-lt=
             "processing">processing a manifest</dfn> are given by the following
             algorithm. The algorithm takes a [=URL=] |document URL:URL|, a
-            [=URL=] |manifest URL:URL|, a [=byte sequence=] |bodyBytes|, and an
-            optional [=environment settings object=] |client|.
+            [=URL=] |manifest URL:URL|, a [=byte sequence=] |bodyBytes|, and
+            |client| (an [=environment settings object=] or null).
           </p>
           <ol class="algorithm">
             <li>Let |json| be the result of [=parse JSON bytes to an Infra
@@ -1682,8 +1682,7 @@
             any proprietary and/or other supported members at this point in the
             algorithm.
             </li>
-            <li>Set |manifest|'s <dfn data-dfn-for="application manifest"
-            data-export="">client</dfn> to |client|.
+            <li>Set |manifest|'s <dfn data-dfn-for="application manifest">client</dfn> to |client|.
             </li>
             <li>Let [=document=]'s <dfn data-export="" data-dfn-for="Document">
               processed manifest</dfn> be |manifest|.
@@ -1995,13 +1994,13 @@
       <ol class="algorithm">
         <li>If |manifest|'s [=application manifest/client=] is null, return.
         </li>
-        <li>Let |request| be a new [=Request=].
+        <li>Let |request| be a new [=request=].
         </li>
         <li>Set |request|'s [=request/URL=] to |image|'s {{ImageResource/src}}.
         </li>
-        <li>Set |request|'s [=request/Destination=] to "`image`".
+        <li>Set |request|'s [=request/destination=] to "`image`".
         </li>
-        <li>Set |request|'s [=request/Client=] to |manifest|'s [=application
+        <li>Set |request|'s [=request/client=] to |manifest|'s [=application
         manifest/client=].
         </li>
         <li>Return the result of [=fetching an image resource=] with |image|

--- a/index.html
+++ b/index.html
@@ -1755,9 +1755,11 @@
           </h3>
           <p>
             The [=processing a manifest=] steps are invoked by [[HTML]]'s
-            processing steps for the [^link^] element, but MAY also be invoked
-            by the user agent to process a manifest without an associated
-            [=document=].
+            processing steps for the [^link^] element, in which case
+            |client| is the [=document=]'s [=relevant settings object=].
+            The steps MAY also be invoked by the user agent to process a
+            manifest without an associated [=document=], in which case
+            |client| is null.
           </p>
           <p>
             In this case, to match the guarantees made by the corresponding

--- a/index.html
+++ b/index.html
@@ -1989,7 +1989,8 @@
       </p>
       <p>
         To <dfn>fetch a manifest image resource</dfn> given a [=manifest image
-        resource=] |image| and an [=application manifest=] |manifest|:
+        resource=] |image| and an [=application manifest=] |manifest|, return
+        either the result of [=fetching an image resource=] or null:
       </p>
       <ol class="algorithm">
         <li>If |manifest|'s [=application manifest/client=] is null, return null.

--- a/index.html
+++ b/index.html
@@ -1992,7 +1992,7 @@
         resource=] |image| and an [=application manifest=] |manifest|:
       </p>
       <ol class="algorithm">
-        <li>If |manifest|'s [=application manifest/client=] is null, return.
+        <li>If |manifest|'s [=application manifest/client=] is null, return null.
           <aside class="note" data-cite="service-workers">
             When a manifest is processed without an associated [=document=],
             |manifest|'s [=application manifest/client=] is null and no image fetch is performed. This ensures

--- a/index.html
+++ b/index.html
@@ -1963,23 +1963,31 @@
         Manifest image resources
       </h2>
       <p>
-        Each <dfn>manifest image resource</dfn> is an [=image resource=] that
-        is conceptually part of a web application, suitable to use in various
-        contexts depending on the semantics of the member that is using the
-        object (e.g., an icon that is part of an application menu, etc.).
+        Each <dfn>manifest image resource</dfn> is an [=image resource=]. The
+        context in which an manifest image resource is presented is determnined
+        by the semantics of the associated manifest member (e.g., an
+        [=manifest/icons=] member is generally used to represent the
+        application icon).
       </p>
       <p>
         A [=manifest image resource=] differs from a [=image resource=] in that
         it can have an additional [=manifest image resource/purpose=] member.
       </p>
       <p>
-        User agents MAY modify the images associated with an [=manifest image
-        resource=] to better match the platform’s visual style before
+        User agents MAY modify the images associated with a [=manifest image
+        resource=] to better match the platform's visual style before
         displaying it to the user, for example by rounding the corners or
         painting it in a specific color. It is recommended that developers
         prepare their image resources for such scenarios to avoid losing
         important information through, e.g., change of color or clipped
         corners.
+      </p>
+      <p>
+        User agents MAY [=fetch=] an [=manifest image resource=] by running the
+        [=fetching an image resource=] algorithm. Alternatively, the user agent
+        MAY delegate [=fetch|fetching=] [=manifest image resources=] to the
+        underlying platform. How the underlying platform fetches a manifest
+        image resource is outside the scope of this specification.
       </p>
       <section>
         <h3>
@@ -2085,53 +2093,6 @@
           <li>Return |purposes|.
           </li>
         </ol>
-      </section>
-      <section>
-        <h3>
-          Content security policy
-        </h3>
-        <p>
-          The security policy that governs whether a <a>user agent</a> can
-          fetch an icon image is governed by the `img-src` directive [[CSP3]]
-          associated with the manifest's owner {{Document}}.
-        </p>
-        <aside class="example" title="Content security policy of icons">
-          <p>
-            For example, given the following `img-src` directive in the
-            `Content-Security-Policy` HTTP header of the manifest's owner
-            {{Document}}:
-          </p>
-          <pre class="http">
-            HTTP/1.1 200 OK
-            Content-Type: text/html
-            Content-Security-Policy: img-src icons.example.com
-
-            &lt;!doctype&gt;
-            &lt;html&gt;
-            &lt;link rel="manifest" href="manifest.webmanifest"&gt;
-          </pre>
-          <p>
-            And given the following `manifest.webmanifest`:
-          </p>
-          <pre class="json">
-            {
-              "name": "custom manifest",
-              "start_url": "https://boo",
-              "icons": [
-                {
-                  "src": "//icons.example.com/lowres"
-                },
-                {
-                  "src": "//other.com/hi-res"
-                }
-              ]
-            }
-          </pre>
-          <p>
-            The fetching of icon resources from `icons.example.com/lowres`
-            would succeed, while fetching from `other.com/hi-res` would fail.
-          </p>
-        </aside>
       </section>
       <section id="icon-masks">
         <h2>

--- a/index.html
+++ b/index.html
@@ -1993,9 +1993,9 @@
       </p>
       <ol class="algorithm">
         <li>If |manifest|'s [=application manifest/client=] is null, return.
-          <aside class="note">
+          <aside class="note" data-cite="service-workers">
             When a manifest is processed without an associated [=document=],
-            |client| is null and no image fetch is performed. This ensures
+            |manifest|'s [=application manifest/client=] is null and no image fetch is performed. This ensures
             that [=enforced|enforcement=] of CSP and [=service worker=] fetch
             interception, which depend on the [=document=]'s [=relevant
             settings object=], remain in effect.
@@ -2014,6 +2014,18 @@
         and |request|.
         </li>
       </ol>
+      <aside class="note">
+        This algorithm is intended to be called when a user agent prepares to
+        present an installation prompt or creates an [=application context=].
+        User agents do not typically call this algorithm during regular page
+        loads. Calling this algorithm requires that the [=application
+        manifest/client=] be set (i.e., the manifest was [=processing a
+        manifest|processed=] in the context of a [=document=]), which ensures
+        that [=Content Security Policy=] and [=service worker=] fetch
+        interception remain in effect. A normative algorithm for when to call
+        this is tracked in issue <a href=
+        "https://github.com/w3c/manifest/issues/1216">#1216</a>.
+      </aside>
       <section>
         <h3>
           `purpose` member

--- a/index.html
+++ b/index.html
@@ -1611,7 +1611,8 @@
             The steps for <dfn data-export="" data-local-lt=
             "processing">processing a manifest</dfn> are given by the following
             algorithm. The algorithm takes a [=URL=] |document URL:URL|, a
-            [=URL=] |manifest URL:URL|, and a [=byte sequence=] |bodyBytes|.
+            [=URL=] |manifest URL:URL|, a [=byte sequence=] |bodyBytes|, and an
+            optional [=environment settings object=] |client|.
           </p>
           <ol class="algorithm">
             <li>Let |json| be the result of [=parse JSON bytes to an Infra
@@ -1680,6 +1681,9 @@
             <li>[=application manifest/Processing extension-point=]: process
             any proprietary and/or other supported members at this point in the
             algorithm.
+            </li>
+            <li>Set |manifest|'s <dfn data-dfn-for="application manifest"
+            data-export="">client</dfn> to |client|.
             </li>
             <li>Let [=document=]'s <dfn data-export="" data-dfn-for="Document">
               processed manifest</dfn> be |manifest|.
@@ -1983,9 +1987,25 @@
         corners.
       </p>
       <p>
-        User agents MUST [=fetch=] a [=manifest image resource=] by running the
-        [=fetching an image resource=] algorithm.
+        To <dfn>fetch a manifest image resource</dfn> given a [=manifest image
+        resource=] |image| and an [=application manifest=] |manifest|:
       </p>
+      <ol class="algorithm">
+        <li>If |manifest|'s [=application manifest/client=] is null, return.
+        </li>
+        <li>Let |request| be a new [=Request=].
+        </li>
+        <li>Set |request|'s [=request/URL=] to |image|'s {{ImageResource/src}}.
+        </li>
+        <li>Set |request|'s [=request/Destination=] to "`image`".
+        </li>
+        <li>Set |request|'s [=request/Client=] to |manifest|'s [=application
+        manifest/client=].
+        </li>
+        <li>Return the result of [=fetching an image resource=] with |image|
+        and |request|.
+        </li>
+      </ol>
       <section>
         <h3>
           `purpose` member

--- a/index.html
+++ b/index.html
@@ -1964,7 +1964,7 @@
       </h2>
       <p>
         Each <dfn>manifest image resource</dfn> is an [=image resource=]. The
-        context in which an manifest image resource is presented is determnined
+        context in which a manifest image resource is presented is determined
         by the semantics of the associated manifest member (e.g., an
         [=manifest/icons=] member is generally used to represent the
         application icon).
@@ -1983,7 +1983,7 @@
         corners.
       </p>
       <p>
-        User agents MUST [=fetch=] an [=manifest image resource=] by running the
+        User agents MUST [=fetch=] a [=manifest image resource=] by running the
         [=fetching an image resource=] algorithm.
       </p>
       <section>
@@ -2090,6 +2090,53 @@
           <li>Return |purposes|.
           </li>
         </ol>
+      </section>
+      <section>
+        <h3>
+          Content security policy
+        </h3>
+        <p>
+          The security policy that governs whether a <a>user agent</a> can
+          fetch an icon image is governed by the `img-src` directive [[CSP3]]
+          associated with the manifest's owner {{Document}}.
+        </p>
+        <aside class="example" title="Content security policy of icons">
+          <p>
+            For example, given the following `img-src` directive in the
+            `Content-Security-Policy` HTTP header of the manifest's owner
+            {{Document}}:
+          </p>
+          <pre class="http">
+            HTTP/1.1 200 OK
+            Content-Type: text/html
+            Content-Security-Policy: img-src icons.example.com
+
+            &lt;!doctype&gt;
+            &lt;html&gt;
+            &lt;link rel="manifest" href="manifest.webmanifest"&gt;
+          </pre>
+          <p>
+            And given the following `manifest.webmanifest`:
+          </p>
+          <pre class="json">
+            {
+              "name": "custom manifest",
+              "start_url": "https://boo",
+              "icons": [
+                {
+                  "src": "//icons.example.com/lowres"
+                },
+                {
+                  "src": "//other.com/hi-res"
+                }
+              ]
+            }
+          </pre>
+          <p>
+            The fetching of icon resources from `icons.example.com/lowres`
+            would succeed, while fetching from `other.com/hi-res` would fail.
+          </p>
+        </aside>
       </section>
       <section id="icon-masks">
         <h2>

--- a/index.html
+++ b/index.html
@@ -1993,6 +1993,13 @@
       </p>
       <ol class="algorithm">
         <li>If |manifest|'s [=application manifest/client=] is null, return.
+          <aside class="note">
+            When a manifest is processed without an associated [=document=],
+            |client| is null and no image fetch is performed. This ensures
+            that [=enforced|enforcement=] of CSP and [=service worker=] fetch
+            interception, which depend on the [=document=]'s [=relevant
+            settings object=], remain in effect.
+          </aside>
         </li>
         <li>Let |request| be a new [=request=].
         </li>

--- a/index.html
+++ b/index.html
@@ -1983,11 +1983,8 @@
         corners.
       </p>
       <p>
-        User agents MAY [=fetch=] an [=manifest image resource=] by running the
-        [=fetching an image resource=] algorithm. Alternatively, the user agent
-        MAY delegate [=fetch|fetching=] [=manifest image resources=] to the
-        underlying platform. How the underlying platform fetches a manifest
-        image resource is outside the scope of this specification.
+        User agents MUST [=fetch=] an [=manifest image resource=] by running the
+        [=fetching an image resource=] algorithm.
       </p>
       <section>
         <h3>

--- a/index.html
+++ b/index.html
@@ -1131,12 +1131,11 @@
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">`background_color`</dfn></code> member is a
           [=manifest/themeable member=] that describes the expected background
-          color of the web application. It repeats what is
-          already available in the application stylesheet but can be used by
-          the <a>user agent</a> to draw the background color of a web
-          application for which the manifest is known before the files are
-          actually available, whether they are fetched from the network or
-          retrieved from disk.
+          color of the web application. It repeats what is already available in
+          the application stylesheet but can be used by the <a>user agent</a>
+          to draw the background color of a web application for which the
+          manifest is known before the files are actually available, whether
+          they are fetched from the network or retrieved from disk.
         </p>
         <p>
           The [=manifest/background_color=] member is only meant to improve the
@@ -1507,18 +1506,20 @@
         <p>
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">color_scheme_dark</dfn></code> member is an [=ordered
-          map=] whose keys are [=manifest/themeable members=] and whose
-          values are the overriding color values for those members when the
-          operating system uses a dark color theme.
+          map=] whose keys are [=manifest/themeable members=] and whose values
+          are the overriding color values for those members when the operating
+          system uses a dark color theme.
         </p>
         <p>
           A <dfn data-dfn-for="manifest">themeable member</dfn> is one of the
           following [=manifest=] members:
-          <ul>
-            <li>[=manifest/theme_color=]</li>
-            <li>[=manifest/background_color=]</li>
-          </ul>
         </p>
+        <ul>
+          <li>[=manifest/theme_color=]
+          </li>
+          <li>[=manifest/background_color=]
+          </li>
+        </ul>
         <p>
           When [=applying=] a manifest and the operating system uses a dark
           color theme, for each [=manifest/themeable member=] |member| that
@@ -1561,8 +1562,8 @@
             <li>[=Map/Set=] |manifest|["color_scheme_dark"] to
             |processedColorScheme|.
             </li>
-            <li>[=List/For each=] |member:string| of
-            « "theme_color", "background_color" »:
+            <li>[=List/For each=] |member:string| of « "theme_color",
+            "background_color" »:
               <ol>
                 <li>[=Process a color member=] passing |colorScheme|,
                 |processedColorScheme|, |member|.
@@ -1682,7 +1683,8 @@
             any proprietary and/or other supported members at this point in the
             algorithm.
             </li>
-            <li>Set |manifest|'s <dfn data-dfn-for="application manifest">client</dfn> to |client|.
+            <li>Set |manifest|'s <dfn data-dfn-for=
+            "application manifest">client</dfn> to |client|.
             </li>
             <li>Let [=document=]'s <dfn data-export="" data-dfn-for="Document">
               processed manifest</dfn> be |manifest|.
@@ -1754,11 +1756,10 @@
           </h3>
           <p>
             The [=processing a manifest=] steps are invoked by [[HTML]]'s
-            processing steps for the [^link^] element, in which case
-            |client| is the [=document=]'s [=relevant settings object=].
-            The steps MAY also be invoked by the user agent to process a
-            manifest without an associated [=document=], in which case
-            |client| is null.
+            processing steps for the [^link^] element, in which case |client|
+            is the [=document=]'s [=relevant settings object=]. The steps MAY
+            also be invoked by the user agent to process a manifest without an
+            associated [=document=], in which case |client| is null.
           </p>
           <p>
             In this case, to match the guarantees made by the corresponding
@@ -1817,22 +1818,23 @@
             [=apply=] a manifest to it before [=navigate|navigation=] begins.
           </p>
           <p>
-            A user agent MAY also [=apply=] a manifest to an existing [=top-level
-            browsing context=]. If the [=navigable/active document=]'s
-            [=Document/URL=] is [=manifest/within scope=] of the manifest, the
-            existing [=top-level browsing context=] becomes an [=application
-            context=]. If the [=Document/URL=] is not [=manifest/within scope=],
-            the resulting behavior is implementation-defined.
+            A user agent MAY also [=apply=] a manifest to an existing
+            [=top-level browsing context=]. If the [=navigable/active
+            document=]'s [=Document/URL=] is [=manifest/within scope=] of the
+            manifest, the existing [=top-level browsing context=] becomes an
+            [=application context=]. If the [=Document/URL=] is not
+            [=manifest/within scope=], the resulting behavior is
+            implementation-defined.
           </p>
           <aside class="note">
             <p>
               Some user agents might [=apply=] a manifest to the existing
               [=top-level browsing context=] from which installation was
-              initiated. If the [=navigable/active document=]'s [=Document/URL=]
-              is not [=manifest/within scope=] of the manifest's
-              [=manifest/navigation scope=], one possible behavior is that the
-              [=application context=] initially exists at an out-of-scope
-              [=Document/URL=].
+              initiated. If the [=navigable/active document=]'s
+              [=Document/URL=] is not [=manifest/within scope=] of the
+              manifest's [=manifest/navigation scope=], one possible behavior
+              is that the [=application context=] initially exists at an
+              out-of-scope [=Document/URL=].
             </p>
           </aside>
           <aside class="note">
@@ -1993,13 +1995,14 @@
         either the result of [=fetching an image resource=] or null:
       </p>
       <ol class="algorithm">
-        <li>If |manifest|'s [=application manifest/client=] is null, return null.
-          <aside class="note" data-cite="service-workers">
+        <li>If |manifest|'s [=application manifest/client=] is null, return
+        null.
+          <aside class="note" data-cite="SERVICE-WORKERS">
             When a manifest is processed without an associated [=document=],
-            |manifest|'s [=application manifest/client=] is null and no image fetch is performed. This ensures
-            that [=enforced|enforcement=] of CSP and [=service worker=] fetch
-            interception, which depend on the [=document=]'s [=relevant
-            settings object=], remain in effect.
+            |manifest|'s [=application manifest/client=] is null and no image
+            fetch is performed. This ensures that [=enforced|enforcement=] of
+            CSP and [=service worker=] fetch interception, which depend on the
+            [=document=]'s [=relevant settings object=], remain in effect.
           </aside>
         </li>
         <li>Let |request| be a new [=request=].
@@ -2015,7 +2018,7 @@
         and |request|.
         </li>
       </ol>
-      <aside class="note">
+      <aside class="note" data-cite="SERVICE-WORKERS">
         This algorithm is intended to be called when a user agent prepares to
         present an installation prompt or creates an [=application context=].
         User agents do not typically call this algorithm during regular page
@@ -2830,7 +2833,7 @@
           path-structural (e.g. a target URL string `/prefix-of/resource.html`
           will match an app with scope `/prefix`, even though the path segment
           name is not an exact match). This is intentional for consistency with
-          <a data-cite="SERVICE-WORKERS-1#scope-match-algorithm">Service
+          <a data-cite="SERVICE-WORKERS#scope-match-algorithm">Service
           Workers</a>. To avoid unexpected behavior, use a scope ending in a
           `/`.
         </p>


### PR DESCRIPTION
Closes #910

This change (choose at least one, delete ones that don't apply):

* Makes a normative change (adds a proper fetch algorithm for manifest image resources, with client and mode requirements)

## What changed

1. **Added `client` parameter to "processing a manifest"** — an optional environment settings object. When HTML invokes processing via `<link rel="manifest">`, this is the document's relevant settings object. When processing without a document (e.g., sync install), it is null.

2. **Stored `client` on the processed manifest** — so it's available later when image resources need to be fetched.

3. **Added "fetch a manifest image resource" algorithm** — creates a Request with:
   - URL from the image resource's `src`
   - destination set to `"image"`
   - client set to the manifest's stored client (for CSP and service worker interception)
   - Delegates to the Image Resource spec's "fetching an image resource" algorithm, which sets mode to `"cors"` (see [w3c/image-resource#50](https://github.com/w3c/image-resource/pull/50))

4. **Clarified the HTML invocation context** — the "Processing without a document" section now explains when `client` is the document's relevant settings object vs. null.

## Implementation commitment

* [ ] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=311872) — currently non-conformant. Manifest icon fetches are routed directly to the network process, bypassing the document context. CSP `img-src` directives and service workers do not apply.
* [x] Chromium — fetches manifest icons through the document frame via `DownloadImageInFrame()`. Service workers can intercept (confirmed by @dmurph). Does not explicitly set a fetch mode.
* [x] Gecko — fetches manifest icons via `window.fetch()` through the content window. CSP and service workers apply. Firefox explicitly sets `mode: "cors"`.

## Related

- [w3c/image-resource#50](https://github.com/w3c/image-resource/pull/50) — sets fetch mode to `cors` in the Image Resource spec's algorithm

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* ~~chore:~~
* ~~editorial:~~
* ~~BREAKING CHANGE:~~
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1171.html" title="Last updated on Apr 24, 2026, 2:18 AM UTC (597493c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1171/c5b38d2...597493c.html" title="Last updated on Apr 24, 2026, 2:18 AM UTC (597493c)">Diff</a>