### PR TITLE
chore: export Installed Web Application Identity

### DIFF
--- a/index.html
+++ b/index.html
@@ -863,8 +863,10 @@
         <p>
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">id</dfn></code> member is a <a>string</a> that represents
-          the <dfn>identity</dfn> for the application. The [=identity=] takes
-          the form of a URL, which is same origin as the [=start URL=].
+          the <dfn class="export" data-dfn-for=
+          "installed web application">identity</dfn> for the application. The
+          [=identity=] takes the form of a URL, which is same origin as the
+          [=start URL=].
         </p>
         <p>
           The [=identity=] is used by user agents to uniquely identify the

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
         </li>
         <li>[=manifest/icons=]
         </li>
-        <li>[=manifest/identity=]
+        <li>[=manifest/id=]
         </li>
         <li>[=manifest/lang=]
         </li>
@@ -865,18 +865,19 @@
           "manifest">id</dfn></code> member is a <a>string</a> that represents
           the <dfn class="export" data-dfn-for=
           "installed web application">identity</dfn> for the application. The
-          [=identity=] takes the form of a URL, which is same origin as the
-          [=start URL=].
+          [=installed web application/identity=] takes the form of a URL, which
+          is same origin as the [=start URL=].
         </p>
         <p>
-          The [=identity=] is used by user agents to uniquely identify the
-          application universally. When the user agent sees a manifest with an
-          [=identity=] that does not correspond to an already-installed
-          application, it SHOULD treat that manifest as a description of a
-          distinct application, even if it is served from the same URL as that
-          of another application. When the user agent sees a manifest where
-          |manifest|["id"] is [=url/equal=] (with [=URL/equals/exclude
-          fragments=] OPTIONALLY set to true) to the [=identity=] of an
+          The [=installed web application/identity=] is used by user agents to
+          uniquely identify the application universally. When the user agent
+          sees a manifest with an [=installed web application/identity=] that
+          does not correspond to an already-installed application, it SHOULD
+          treat that manifest as a description of a distinct application, even
+          if it is served from the same URL as that of another application.
+          When the user agent sees a manifest where |manifest|["id"] is
+          [=url/equal=] (with [=URL/equals/exclude fragments=] OPTIONALLY set
+          to true) to the [=installed web application/identity=] of an
           already-installed application, it SHOULD be used as a signal that
           this manifest is a replacement for the already-installed
           application's manifest, and not a distinct application, even if it is
@@ -896,13 +897,14 @@
           two [=URLs=] that ought not to have fragments.
         </aside>
         <p class="note">
-          The [=identity=] can be used by a service that collects lists of web
-          applications to uniquely identify applications.
+          The [=installed web application/identity=] can be used by a service
+          that collects lists of web applications to uniquely identify
+          applications.
         </p>
         <p class="note">
-          The [=identity=] is processed like a URL but it doesn't point to a
-          resource that can be navigated to, so it's not required to be
-          [=URL/within scope=].
+          The [=installed web application/identity=] is processed like a URL
+          but it doesn't point to a resource that can be navigated to, so it's
+          not required to be [=URL/within scope=].
         </p>
         <p>
           To <dfn>process the `id` member</dfn>, given [=ordered map=]


### PR DESCRIPTION
This change (choose at least one, delete ones that don't apply):

* Is a "chore" (metadata, formatting, fixing warnings, etc).

Need this for https://github.com/w3c/push-api/pull/402


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1187.html" title="Last updated on Sep 2, 2025, 6:58 AM UTC (3b838bf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1187/8ff396e...3b838bf.html" title="Last updated on Sep 2, 2025, 6:58 AM UTC (3b838bf)">Diff</a>