### PR TITLE
Update manifest spec to consider manifest updates for icon urls to be cache-control:immutable

### DIFF
--- a/index.html
+++ b/index.html
@@ -1771,11 +1771,23 @@
           </h3>
           <p>
             As specified for [^link/rel/manifest^] link relation, the manifest
-            is fetched and processed on every page load. When the [=processing
-            a manifest=] is successful, user agents MAY apply updated manifest
+            is fetched and processed on every page load. When [=processing
+            a manifest=] is successful, user agents MAY apply the updated manifest
             to any current and future <a>application contexts</a> associated
             with the application.
           </p>
+          <p>
+            The user agent SHOULD consider a [=manifest image resource=] updated
+            if the {{ImageResource/src}} member has changed. If the
+            {{ImageResource/src}} has not changed, the user agent MAY download the
+            image and check for visual differences in some cases.
+          </p>
+          <aside class="note" title="Icon metadata changes">
+            <p>
+              The way a [=manifest image resource=] is parsed for updates is similar
+              to the `Cache-Control:immutable` behavior outlined in [[RFC8246]].
+            </p>
+          </aside>
           <p>
             For the purpose of updating, the following member are
             <dfn>security-sensitive members</dfn>, as they are presented during
@@ -1793,39 +1805,34 @@
             </li>
           </ol>
           <p>
-            All other members of the manifest are considered as a
-            <dfn>non security-sensitive member</dfn>.
+            All other members of the manifest are considered as
+            <dfn data-lt="non-security-sensitive member" data-lt-noDefault>non-security-sensitive members</dfn>.
           </p>
           <p>
-            A <dfn>security-sensitive update</dfn> is a significant change in one of the
-            [=security-sensitive members=], determined by the user agent. Respectively,
-            an update to a [=non security-sensitive member=] is a
-            <dfn>non security-sensitive update</dfn>.
+            A <dfn>security-sensitive update</dfn> is a update to a [=security-sensitive
+            member=]. Respectively, a <dfn>non-security-sensitive update</dfn> is a
+            update to a [=non-security-sensitive member=].
           </p>
           <p>
-            When considering a [=security-sensitive update=] for a [=manifest image resource=], 
-            the user agent SHOULD consider a [=manifest image resource=] updated
-            if the {{ImageResource/src}} member has changed. If the
-            {{ImageResource/src}} has not changed, the user agent MAY download the
-            image and check for visual differences in some cases. Finally, the user agent
-            MAY change a [=security-sensitive update=] in a [=manifest image resource=] to a
-            [=non security-sensitive update=] if the images are not significantly
-            visually different.
+            When considering an updated [=security-sensitive member=] of type [=manifest image resource=]
+            (e.g. [=manifest/icons=]), the user agent MAY consider it a [=non-security-sensitive
+            update=] if the user agent finds the image not significantly visually
+            different.
           </p>
-          <aside class="note" title="Icon metadata changes">
-            <p>
-              The way a [=manifest image resource=] is parsed for updates is similar
-              to the `Cache-Control:immutable` behavior outlined in [[RFC8246]].
-            </p>
-          </aside>
           <p>
-            The user agent SHOULD apply all [=non security-sensitive updates=]
+            The user agent SHOULD apply all [=non-security-sensitive updates=]
             immediately.
           </p>
           <p data-cite="permissions">
             The user agent SHOULD present all [=security-sensitive updates=]
             to the user and require [=express permission=] before applying the
-            changes. The user should be given the option to either:
+            changes. 
+          </p>
+          <aside class="note" title="Example user options displayed when presented with the update">
+            <p>
+            The user may be presented with the following options when shown
+                  [=security-sensitive updates=]:
+            </p>
             <ol>
               <li>Accept the update
               </li>
@@ -1834,7 +1841,7 @@
               <li>Ignore the update
               </li>
             </ol>
-          </p>
+          </aside>
           <p>
             [=Security-sensitive members=] SHOULD be displayed in a
             bidirectionally isolated way as described in [[UTS55]], regardless


### PR DESCRIPTION
This change (choose at least one, delete ones that don't apply):

* Adds new normative requirements

Implementation commitment (delete if not making normative changes):

* [ ] WebKit (https://bugs.webkit.org)
* [X] Chromium (https://crbug.com/403252561)
* [ ] Gecko (http://bugzilla.mozilla.org)

Commit message:

This change updates the manifest specification to consider manifest updates only if the icon urls have changed, mimicking the cache-control:immutable behavior.

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Dp-Goog/manifest/pull/1199.html" title="Last updated on Dec 30, 2025, 6:33 PM UTC (6a2cf15)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1199/6d104be...Dp-Goog:6a2cf15.html" title="Last updated on Dec 30, 2025, 6:33 PM UTC (6a2cf15)">Diff</a>