### PR TITLE
Clarify applying manifest to an existing browsing context

### DIFF
--- a/index.html
+++ b/index.html
@@ -2717,6 +2717,14 @@
           third-party authentication). See <a href=
           "https://github.com/w3c/manifest/issues/646">Issue 646</a>.
         </p>
+        <p>
+          Some user agents might directly [=launch a web application|launch=]
+          the [=installed web application=] using the [=Document/URL=] of the
+          [=browsing context=] that initiated the installation. If the
+          [=Document/URL=] of this page is not [=manifest/within scope=] of the
+          manifest's [=manifest/navigation scope=], the [=application context=]
+          is initially instantiated with an out-of-scope [=Document/URL=].
+        </p>
       </aside>
       <section class="informative">
         <h3 id="navigation-scope-security-considerations">

--- a/index.html
+++ b/index.html
@@ -1733,6 +1733,25 @@
             [=top-level browsing context=] is created, the user agent MAY
             [=apply=] a manifest to it before [=navigate|navigation=] begins.
           </p>
+          <p>
+            A user agent MAY also [=apply=] a manifest to an existing [=top-level
+            browsing context=]. If the [=navigable/active document=]'s
+            [=Document/URL=] is [=manifest/within scope=] of the manifest, the
+            existing [=top-level browsing context=] becomes an [=application
+            context=]. If the [=Document/URL=] is not [=manifest/within scope=],
+            the resulting behavior is implementation-defined.
+          </p>
+          <aside class="note">
+            <p>
+              Some user agents might [=apply=] a manifest to the existing
+              [=top-level browsing context=] from which installation was
+              initiated. If the [=navigable/active document=]'s [=Document/URL=]
+              is not [=manifest/within scope=] of the manifest's
+              [=manifest/navigation scope=], one possible behavior is that the
+              [=application context=] initially exists at an out-of-scope
+              [=Document/URL=].
+            </p>
+          </aside>
           <aside class="note">
             Whether to [=apply=] a manifest, and which manifest to apply, is at
             the discretion of the user agent, based on the user's actions. For
@@ -2716,14 +2735,6 @@
           some sites that navigate to an off-scope URL (e.g., to perform
           third-party authentication). See <a href=
           "https://github.com/w3c/manifest/issues/646">Issue 646</a>.
-        </p>
-        <p>
-          Some user agents might directly [=launch a web application|launch=]
-          the [=installed web application=] using the [=Document/URL=] of the
-          [=browsing context=] that initiated the installation. If the
-          [=Document/URL=] of this page is not [=manifest/within scope=] of the
-          manifest's [=manifest/navigation scope=], the [=application context=]
-          is initially instantiated with an out-of-scope [=Document/URL=].
         </p>
       </aside>
       <section class="informative">


### PR DESCRIPTION
Closes #784

This change:

* Adds new normative requirements

Adds normative text to the [Applying the manifest](https://w3c.github.io/manifest/#applying) section covering the case where a user agent applies a manifest to an *existing* top-level browsing context (e.g., immediately after installation). The two cases are now specified:

- If the active document's URL is within scope: the browsing context becomes an application context.
- If the active document's URL is not within scope: the behavior is implementation-defined.

An informative note illustrates the implementation-defined case (e.g., Chromium's tab-promotion behavior).

The original note added by this PR has been moved from the navigation scope section to sit adjacent to the new normative text, and revised for consistency (replacing `[=launch=]` with `[=apply=]`, which correctly describes applying to an existing context rather than creating a new one).

Implementation commitment: no implementation changes required — the normative text formalizes existing behavior and explicitly leaves the out-of-scope case as implementation-defined.

Commit message:

Add normative text for applying manifest to existing browsing context


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1202.html" title="Last updated on Apr 9, 2026, 5:30 PM UTC (4d7e980)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1202/6731c8c...4d7e980.html" title="Last updated on Apr 9, 2026, 5:30 PM UTC (4d7e980)">Diff</a>