### PR TITLE
Editorial: map definition of `minimal-ui` to `window.open()` with `features` set to `"popup"`

### DIFF
--- a/index.html
+++ b/index.html
@@ -2817,7 +2817,9 @@
           controlling navigation (i.e., back, forward, reload, and perhaps some
           way of viewing the document's address). A user agent can include
           other platform specific UI elements, such as "share" and "print"
-          buttons or whatever is customary on the platform and user agent.
+          buttons or whatever is customary on the platform and user agent. This
+          is comparable to opening a window via {{Window/open()}} with
+          `features` set to "`popup`".
         </dd>
         <dt>
           <dfn class="export" data-dfn-for="display mode">browser</dfn>


### PR DESCRIPTION
Closes #1023

This change (choose at least one, delete ones that don't apply):

* Adds new normative recommendations or optional items

Implementation commitment (delete if not making normative changes):

* [ ] WebKit (https://bugs.webkit.org)
* [ ] Chromium (https://bugs.chromium.org/)
* [ ] Gecko (http://bugzilla.mozilla.org)

Commit message:

Editorial: map definition of `minimal-ui` to `window.open()` with `features` set to `"popup"`

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1203.html" title="Last updated on Jan 29, 2026, 5:17 PM UTC (e08d9f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1203/25f88f1...e08d9f7.html" title="Last updated on Jan 29, 2026, 5:17 PM UTC (e08d9f7)">Diff</a>