### PR TITLE
Add `color_scheme_dark` member and themeable members (colors only)

### DIFF
--- a/index.html
+++ b/index.html
@@ -662,7 +662,8 @@
           system preferences.
         </p>
         <p>
-          The [=manifest/icons=] member is a [=localizable member=].
+          The [=manifest/icons=] member is a [=localizable member=] and a
+          [=themeable member=].
         </p>
         <aside class="note">
           <p>
@@ -1093,6 +1094,9 @@
           <dfn>theme color</dfn> is defined in [[HTML]].
         </p>
         <p>
+          The [=manifest/theme_color=] member is a [=themeable member=].
+        </p>
+        <p>
           If the user agent honors the value of the [=manifest/theme_color=]
           member as the [=default theme color=], then that color serves as the
           [=theme color=] for all [=browsing contexts=] to which the manifest
@@ -1134,6 +1138,9 @@
           application for which the manifest is known before the files are
           actually available, whether they are fetched from the network or
           retrieved from disk.
+        </p>
+        <p>
+          The [=manifest/background_color=] member is a [=themeable member=].
         </p>
         <p>
           The [=manifest/background_color=] member is only meant to improve the
@@ -1498,6 +1505,105 @@
         </section>
       </section>
       <section>
+        <h3>
+          `color_scheme_dark` member
+        </h3>
+        <p>
+          The [=manifest's=] <code><dfn data-export="" data-dfn-for=
+          "manifest">color_scheme_dark</dfn></code> member is an [=ordered
+          map=] whose keys are the names of [=themeable members=] and their
+          corresponding [=localizable members=], while the values are their
+          corresponding theme overrides.
+        </p>
+        <p>
+          A <dfn>themeable member</dfn> is a [=manifest=] member that can be
+          themed.
+        </p>
+        <aside class="example" title=
+        "Example manifest with a dark theme and localizations">
+          <pre class="json">
+            { 
+              "lang": "en",
+              "name": "Cool App",
+              "name_localized": { "de": "Coole App" },
+              "background_color": "#fff",
+              "theme_color": "red",
+              "shortcuts": [{
+                "name": "Cool Shortcut",
+                "name_localized": { "de": "Cooler Shortcut" },
+                "url": "/",
+                "icons": [{ "src": "shortcut.png" }],
+                "icons_localized": { "de": [{ "src": "shortcut-de.png" }] },
+                "color_scheme_dark": {
+                  "icons": [{ "src": "shortcut-dark.png" }],
+                  "icons_localized": { "de": [{ "src": "shortcut-dark-de.png" }] }
+                }
+              }],
+              "icons": [{ "src": "icon.png" }],
+              "icons_localized": { "de": [{ "src": "icon-de.png" }] },
+              "color_scheme_dark": {
+                "background_color": "#000",
+                "theme_color": "hotpink",
+                "icons": [{ "src": "icon-dark.png" }],
+                "icons_localized": { "de": [{ "src": "icon-dark-de.png" }] }
+              }
+            }
+        </pre>
+        </aside>
+        <p>
+          The user agent SHOULD use the user's system theme preference (e.g.,
+          dark mode) to apply the values from [=manifest/color_scheme_dark=]
+          when appropriate.
+        </p>
+        <aside class="note">
+          Because the [=themeable members=] were defined prior to the
+          introduction of dark mode, they are implicitly treated as the light
+          theme representation.
+        </aside>
+        <section>
+          <h3>
+            Theming themeable members
+          </h3>
+          <p>
+            The [=manifest/color_scheme_dark=] member's [=ordered map=] accepts
+            [=themeable members=] as keys, and their values as the theme
+            overrides.
+          </p>
+          <p>
+            To <dfn>process the `color_scheme_dark` member</dfn>, given
+            [=ordered map=] |json:ordered map|, [=ordered map=]
+            |manifest:ordered map|, and [=URL=] |manifest URL:URL|:
+          </p>
+          <ol class="algorithm">
+            <li>If |json|["color_scheme_dark"] does not [=map/exist=], return.
+            </li>
+            <li>Let |colorScheme| be |json|["color_scheme_dark"].
+            </li>
+            <li>If |colorScheme| is not an [=ordered map=], return.
+            </li>
+            <li>Let |processedColorScheme:ordered map| be a new [=ordered
+            map=].
+            </li>
+            <li>[=Map/Set=] |manifest|["color_scheme_dark"] to
+            |processedColorScheme|.
+            </li>
+            <li>[=Process a color member=] passing |colorScheme|,
+            |processedColorScheme|, "theme_color".
+            </li>
+            <li>[=Process a color member=] passing |colorScheme|,
+            |processedColorScheme|, "background_color".
+            </li>
+            <li>[=Process image resources=] passing |colorScheme|["icons"],
+            |processedColorScheme|, |manifest URL|, and "icons".
+            </li>
+            <li>[=Process a `*_localized` image resource member=] passing
+            |colorScheme|, |processedColorScheme|, "icons_localized", and
+            |manifest URL|.
+            </li>
+          </ol>
+        </section>
+      </section>
+      <section>
         <h2>
           Manifest life-cycle
         </h2>
@@ -1592,6 +1698,9 @@
             </li>
             <li>[=Process a `*_localized` image resource member=] passing
             |json|, |manifest|, "icons_localized", and |manifest URL|.
+            </li>
+            <li>[=Process the `color_scheme_dark` member=] passing |json|,
+            |manifest|, and |manifest URL|.
             </li>
             <li>[=Process the `orientation` member=] passing |json|,
             |manifest|.
@@ -2302,6 +2411,8 @@
         </li>
         <li>[=shortcut item/icons=]
         </li>
+        <li>[=shortcut item/color_scheme_dark=]
+        </li>
       </ul>
       <p>
         A user agent can use these members to assemble a context menu to be
@@ -2373,7 +2484,25 @@
           iconic representations of the shortcut in various contexts.
         </p>
         <p>
-          The [=shortcut item/icons=] member is a [=localizable member=].
+          The [=shortcut item/icons=] member is a [=localizable member=] and a
+          [=themeable member=].
+        </p>
+      </section>
+      <section>
+        <h3>
+          `color_scheme_dark` member
+        </h3>
+        <p>
+          The [=shortcut item's=] <code><dfn data-dfn-for=
+          "shortcut item">color_scheme_dark</dfn></code> member is an [=ordered
+          map=] whose keys are the names of [=themeable members=] and their
+          corresponding [=localizable members=], while the values are their
+          corresponding theme overrides.
+        </p>
+        <p>
+          The user agent SHOULD use the user's system theme preference (e.g.,
+          dark mode) to apply the values from [=shortcut
+          item/color_scheme_dark=] when appropriate.
         </p>
       </section>
       <section>
@@ -2443,6 +2572,26 @@
           </li>
           <li>[=Process a `*_localized` image resource member=] passing |item|,
           |shortcut|, "icons_localized", and |manifest URL|.
+          </li>
+          <li>If "color_scheme_dark" [=map/exists=] in |item| and
+          |item|["color_scheme_dark"] is an [=ordered map=]:
+            <ol>
+              <li>Let |colorScheme| be |item|["color_scheme_dark"].
+              </li>
+              <li>Let |processedColorScheme:ordered map| be a new [=ordered
+              map=].
+              </li>
+              <li>[=Map/Set=] |shortcut|["color_scheme_dark"] to
+              |processedColorScheme|.
+              </li>
+              <li>[=Process image resources=] passing |colorScheme|["icons"],
+              |processedColorScheme|, |manifest URL|, and "icons".
+              </li>
+              <li>[=Process a `*_localized` image resource member=] passing
+              |colorScheme|, |processedColorScheme|, "icons_localized", and
+              |manifest URL|.
+              </li>
+            </ol>
           </li>
           <li>Return |shortcut|.
           </li>

--- a/index.html
+++ b/index.html
@@ -662,8 +662,7 @@
           system preferences.
         </p>
         <p>
-          The [=manifest/icons=] member is a [=localizable member=] and a
-          [=themeable member=].
+          The [=manifest/icons=] member is a [=localizable member=].
         </p>
         <aside class="note">
           <p>
@@ -1511,41 +1510,21 @@
         <p>
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">color_scheme_dark</dfn></code> member is an [=ordered
-          map=] whose keys are the names of [=themeable members=] and their
-          corresponding [=localizable members=], while the values are their
-          corresponding theme overrides.
+          map=] whose keys are the names of [=themeable members=], while the
+          values are their corresponding theme overrides.
         </p>
         <p>
           A <dfn>themeable member</dfn> is a [=manifest=] member that can be
           themed.
         </p>
-        <aside class="example" title=
-        "Example manifest with a dark theme and localizations">
+        <aside class="example" title="Example manifest with a dark theme">
           <pre class="json">
             { 
-              "lang": "en",
-              "name": "Cool App",
-              "name_localized": { "de": "Coole App" },
               "background_color": "#fff",
               "theme_color": "red",
-              "shortcuts": [{
-                "name": "Cool Shortcut",
-                "name_localized": { "de": "Cooler Shortcut" },
-                "url": "/",
-                "icons": [{ "src": "shortcut.png" }],
-                "icons_localized": { "de": [{ "src": "shortcut-de.png" }] },
-                "color_scheme_dark": {
-                  "icons": [{ "src": "shortcut-dark.png" }],
-                  "icons_localized": { "de": [{ "src": "shortcut-dark-de.png" }] }
-                }
-              }],
-              "icons": [{ "src": "icon.png" }],
-              "icons_localized": { "de": [{ "src": "icon-de.png" }] },
               "color_scheme_dark": {
                 "background_color": "#000",
-                "theme_color": "hotpink",
-                "icons": [{ "src": "icon-dark.png" }],
-                "icons_localized": { "de": [{ "src": "icon-dark-de.png" }] }
+                "theme_color": "hotpink"
               }
             }
         </pre>
@@ -1592,13 +1571,6 @@
             </li>
             <li>[=Process a color member=] passing |colorScheme|,
             |processedColorScheme|, "background_color".
-            </li>
-            <li>[=Process image resources=] passing |colorScheme|["icons"],
-            |processedColorScheme|, |manifest URL|, and "icons".
-            </li>
-            <li>[=Process a `*_localized` image resource member=] passing
-            |colorScheme|, |processedColorScheme|, "icons_localized", and
-            |manifest URL|.
             </li>
           </ol>
         </section>
@@ -2411,8 +2383,6 @@
         </li>
         <li>[=shortcut item/icons=]
         </li>
-        <li>[=shortcut item/color_scheme_dark=]
-        </li>
       </ul>
       <p>
         A user agent can use these members to assemble a context menu to be
@@ -2484,25 +2454,7 @@
           iconic representations of the shortcut in various contexts.
         </p>
         <p>
-          The [=shortcut item/icons=] member is a [=localizable member=] and a
-          [=themeable member=].
-        </p>
-      </section>
-      <section>
-        <h3>
-          `color_scheme_dark` member
-        </h3>
-        <p>
-          The [=shortcut item's=] <code><dfn data-dfn-for=
-          "shortcut item">color_scheme_dark</dfn></code> member is an [=ordered
-          map=] whose keys are the names of [=themeable members=] and their
-          corresponding [=localizable members=], while the values are their
-          corresponding theme overrides.
-        </p>
-        <p>
-          The user agent SHOULD use the user's system theme preference (e.g.,
-          dark mode) to apply the values from [=shortcut
-          item/color_scheme_dark=] when appropriate.
+          The [=shortcut item/icons=] member is a [=localizable member=].
         </p>
       </section>
       <section>
@@ -2572,26 +2524,6 @@
           </li>
           <li>[=Process a `*_localized` image resource member=] passing |item|,
           |shortcut|, "icons_localized", and |manifest URL|.
-          </li>
-          <li>If "color_scheme_dark" [=map/exists=] in |item| and
-          |item|["color_scheme_dark"] is an [=ordered map=]:
-            <ol>
-              <li>Let |colorScheme| be |item|["color_scheme_dark"].
-              </li>
-              <li>Let |processedColorScheme:ordered map| be a new [=ordered
-              map=].
-              </li>
-              <li>[=Map/Set=] |shortcut|["color_scheme_dark"] to
-              |processedColorScheme|.
-              </li>
-              <li>[=Process image resources=] passing |colorScheme|["icons"],
-              |processedColorScheme|, |manifest URL|, and "icons".
-              </li>
-              <li>[=Process a `*_localized` image resource member=] passing
-              |colorScheme|, |processedColorScheme|, "icons_localized", and
-              |manifest URL|.
-              </li>
-            </ol>
           </li>
           <li>Return |shortcut|.
           </li>

--- a/index.html
+++ b/index.html
@@ -1088,12 +1088,10 @@
         </h3>
         <p>
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
-          "manifest">theme_color</dfn></code> member serves as the <dfn>default
-          theme color</dfn> for an application context. What constitutes a
-          <dfn>theme color</dfn> is defined in [[HTML]].
-        </p>
-        <p>
-          The [=manifest/theme_color=] member is a [=manifest/themeable member=].
+          "manifest">theme_color</dfn></code> member is a [=manifest/themeable
+          member=] that serves as the <dfn>default theme color</dfn> for an
+          application context. What constitutes a <dfn>theme color</dfn> is
+          defined in [[HTML]].
         </p>
         <p>
           If the user agent honors the value of the [=manifest/theme_color=]
@@ -1130,16 +1128,14 @@
         </h3>
         <p>
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
-          "manifest">`background_color`</dfn></code> member describes the
-          expected background color of the web application. It repeats what is
+          "manifest">`background_color`</dfn></code> member is a
+          [=manifest/themeable member=] that describes the expected background
+          color of the web application. It repeats what is
           already available in the application stylesheet but can be used by
           the <a>user agent</a> to draw the background color of a web
           application for which the manifest is known before the files are
           actually available, whether they are fetched from the network or
           retrieved from disk.
-        </p>
-        <p>
-          The [=manifest/background_color=] member is a [=manifest/themeable member=].
         </p>
         <p>
           The [=manifest/background_color=] member is only meant to improve the
@@ -1522,6 +1518,14 @@
             <li>[=manifest/background_color=]</li>
           </ul>
         </p>
+        <p>
+          When [=applying=] a manifest and the operating system uses a dark
+          color theme, for each [=manifest/themeable member=] |member| that
+          [=map/exists=] in [=manifest/color_scheme_dark=], the user agent
+          SHOULD use the value of [=manifest/color_scheme_dark=][|member|] in
+          place of |member|'s value, unless the user's preferences, such as
+          accessibility settings, take precedence.
+        </p>
         <aside class="example" title="Example manifest with a dark theme">
           <pre class="json">
             {
@@ -1533,18 +1537,6 @@
               }
             }
         </pre>
-        </aside>
-        <p>
-          When [=applying=] a manifest whose operating system uses a dark color
-          theme, for each [=manifest/themeable member=] |member| that
-          [=map/exists=] in [=manifest/color_scheme_dark=], the user agent SHOULD
-          use the value of [=manifest/color_scheme_dark=][|member|] in place of
-          |member|'s value.
-        </p>
-        <aside class="note">
-          Because the [=manifest/themeable members=] were defined before
-          operating systems supported dark color themes, they are implicitly
-          treated as the light color theme values.
         </aside>
         <section>
           <h3>

--- a/index.html
+++ b/index.html
@@ -1093,7 +1093,7 @@
           <dfn>theme color</dfn> is defined in [[HTML]].
         </p>
         <p>
-          The [=manifest/theme_color=] member is a [=themeable member=].
+          The [=manifest/theme_color=] member is a [=manifest/themeable member=].
         </p>
         <p>
           If the user agent honors the value of the [=manifest/theme_color=]
@@ -1139,7 +1139,7 @@
           retrieved from disk.
         </p>
         <p>
-          The [=manifest/background_color=] member is a [=themeable member=].
+          The [=manifest/background_color=] member is a [=manifest/themeable member=].
         </p>
         <p>
           The [=manifest/background_color=] member is only meant to improve the
@@ -1510,16 +1510,16 @@
         <p>
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">color_scheme_dark</dfn></code> member is an [=ordered
-          map=] whose keys are the names of [=themeable members=], while the
+          map=] whose keys are the names of [=manifest/themeable members=], while the
           values are their corresponding theme overrides.
         </p>
         <p>
-          A <dfn>themeable member</dfn> is a [=manifest=] member that can be
+          A <dfn data-dfn-for="manifest">themeable member</dfn> is a [=manifest=] member that can be
           themed.
         </p>
         <aside class="example" title="Example manifest with a dark theme">
           <pre class="json">
-            { 
+            {
               "background_color": "#fff",
               "theme_color": "red",
               "color_scheme_dark": {
@@ -1535,7 +1535,7 @@
           when appropriate.
         </p>
         <aside class="note">
-          Because the [=themeable members=] were defined prior to the
+          Because the [=manifest/themeable members=] were defined prior to the
           introduction of dark mode, they are implicitly treated as the light
           theme representation.
         </aside>
@@ -1545,7 +1545,7 @@
           </h3>
           <p>
             The [=manifest/color_scheme_dark=] member's [=ordered map=] accepts
-            [=themeable members=] as keys, and their values as the theme
+            [=manifest/themeable members=] as keys, and their values as the theme
             overrides.
           </p>
           <p>

--- a/index.html
+++ b/index.html
@@ -1510,12 +1510,17 @@
         <p>
           The [=manifest's=] <code><dfn data-export="" data-dfn-for=
           "manifest">color_scheme_dark</dfn></code> member is an [=ordered
-          map=] whose keys are the names of [=manifest/themeable members=], while the
-          values are their corresponding theme overrides.
+          map=] whose keys are [=manifest/themeable members=] and whose
+          values are the overriding color values for those members when the
+          operating system uses a dark color theme.
         </p>
         <p>
-          A <dfn data-dfn-for="manifest">themeable member</dfn> is a [=manifest=] member that can be
-          themed.
+          A <dfn data-dfn-for="manifest">themeable member</dfn> is one of the
+          following [=manifest=] members:
+          <ul>
+            <li>[=manifest/theme_color=]</li>
+            <li>[=manifest/background_color=]</li>
+          </ul>
         </p>
         <aside class="example" title="Example manifest with a dark theme">
           <pre class="json">
@@ -1530,24 +1535,21 @@
         </pre>
         </aside>
         <p>
-          The user agent SHOULD use the user's system theme preference (e.g.,
-          dark mode) to apply the values from [=manifest/color_scheme_dark=]
-          when appropriate.
+          When [=applying=] a manifest whose operating system uses a dark color
+          theme, for each [=manifest/themeable member=] |member| that
+          [=map/exists=] in [=manifest/color_scheme_dark=], the user agent SHOULD
+          use the value of [=manifest/color_scheme_dark=][|member|] in place of
+          |member|'s value.
         </p>
         <aside class="note">
-          Because the [=manifest/themeable members=] were defined prior to the
-          introduction of dark mode, they are implicitly treated as the light
-          theme representation.
+          Because the [=manifest/themeable members=] were defined before
+          operating systems supported dark color themes, they are implicitly
+          treated as the light color theme values.
         </aside>
         <section>
           <h3>
             Theming themeable members
           </h3>
-          <p>
-            The [=manifest/color_scheme_dark=] member's [=ordered map=] accepts
-            [=manifest/themeable members=] as keys, and their values as the theme
-            overrides.
-          </p>
           <p>
             To <dfn>process the `color_scheme_dark` member</dfn>, given
             [=ordered map=] |json:ordered map|, [=ordered map=]
@@ -1566,11 +1568,13 @@
             <li>[=Map/Set=] |manifest|["color_scheme_dark"] to
             |processedColorScheme|.
             </li>
-            <li>[=Process a color member=] passing |colorScheme|,
-            |processedColorScheme|, "theme_color".
-            </li>
-            <li>[=Process a color member=] passing |colorScheme|,
-            |processedColorScheme|, "background_color".
+            <li>[=List/For each=] |member:string| of
+            « "theme_color", "background_color" »:
+              <ol>
+                <li>[=Process a color member=] passing |colorScheme|,
+                |processedColorScheme|, |member|.
+                </li>
+              </ol>
             </li>
           </ol>
         </section>


### PR DESCRIPTION
Closes #975

This change (choose at least one, delete ones that do not apply):

* Adds new normative requirements

Implementation commitment (delete if not making normative changes):

* [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=311727)
* [x] Chromium ( https://crbug.com/383165202)
* [ ] Gecko (http://bugzilla.mozilla.org)

If change is normative, and it adds or changes a member:

* [ ] [updated JSON schema](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/web-manifest.json)

Commit message:

Add `color_scheme_dark` member and themeable members

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1207.html" title="Last updated on Apr 9, 2026, 5:13 PM UTC (248143a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1207/99738a7...248143a.html" title="Last updated on Apr 9, 2026, 5:13 PM UTC (248143a)">Diff</a>