### PR TITLE
Rename "default display mode" to "applied display mode"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2938,19 +2938,19 @@
       </p>
       <p>
         Once a manifest is [=applied=] to a <a>top-level browsing context</a>,
-        the <a>display mode</a> in effect is the <dfn>applied display
+        the [=display mode=] in effect is the <dfn>applied display
         mode</dfn> for that <a>top-level browsing context</a>. The user agent
-        MAY change the <a>applied display mode</a> for security reasons (e.g.,
+        MAY change the [=applied display mode=] for security reasons (e.g.,
         the <a>top-level browsing context</a> is <a>navigated</a> out of
         scope) and/or the user agent MAY provide the user with a means of
-        switching to another <a>display mode</a>.
+        switching to another [=display mode=].
       </p>
       <p>
         When the [=manifest/display=] member is missing, or if there is no
         valid [=manifest/display=] member, the user agent uses the [=display
-        mode/browser=] <a>display mode</a> as the <a>applied display
-        mode</a>. As such, the user agent MUST support the [=display
-        mode/browser=] <a>display mode</a>.
+        mode/browser=] [=display mode=] as the [=applied display mode=]. As
+        such, the user agent MUST support the [=display mode/browser=]
+        [=display mode=].
       </p>
       <p>
         Every [=display mode=] has a <dfn>fallback chain</dfn>, which is a list
@@ -3014,12 +3014,12 @@
         mode/minimal-ui=]", "[=display mode/browser=]" ».
       </p>
       <p>
-        A user agent MUST reflect the <a>applied display mode</a> of the web
+        A user agent MUST reflect the [=applied display mode=] of the web
         application in the <a data-xref-type="css-descriptor" data-xref-for=
         "@media">`display-mode`</a> media feature [[MEDIAQUERIES-5]].
       </p>
       <p class="note">
-        A user agent will expose the <a>applied display mode</a> — not
+        A user agent will expose the [=applied display mode=] — not
         necessarily the one declared in the manifest — via the
         <a data-xref-type="css-descriptor" data-xref-for=
         "@media">`display-mode`</a> media feature, accessible through CSS or

--- a/index.html
+++ b/index.html
@@ -2937,21 +2937,21 @@
         returns `false`.
       </p>
       <p>
-        Once a user agent [=applies=] a particular <a>display mode</a> to an
-        <a>application context</a>, it becomes the <dfn>default display
-        mode</dfn> for the <a>top-level browsing context</a> (i.e., it is used
-        as the display mode when the window is <a>navigated</a>). The user
-        agent MAY override the <a>default display mode</a> for security reasons
-        (e.g., the <a>top-level browsing context</a> is <a>navigated</a> to
-        another origin) and/or the user agent MAY provide the user with a means
-        of switching to another <a>display mode</a>.
+        Once a manifest is [=applied=] to an <a>application context</a>, the
+        resulting <a>display mode</a> becomes the <dfn>applied display
+        mode</dfn> for the <a>top-level browsing context</a> (i.e., it is
+        the display mode used when the window is <a>navigated</a>). The user
+        agent MAY override the <a>applied display mode</a> for security
+        reasons (e.g., the <a>top-level browsing context</a> is
+        <a>navigated</a> out of scope) and/or the user agent MAY provide the
+        user with a means of switching to another <a>display mode</a>.
       </p>
       <p>
         When the [=manifest/display=] member is missing, or if there is no
         valid [=manifest/display=] member, the user agent uses the [=display
-        mode/browser=] <a>display mode</a> as the <a>default display mode</a>.
-        As such, the user agent MUST support the [=display mode/browser=]
-        <a>display mode</a>.
+        mode/browser=] <a>display mode</a> as the <a>applied display
+        mode</a>. As such, the user agent MUST support the [=display
+        mode/browser=] <a>display mode</a>.
       </p>
       <p>
         Every [=display mode=] has a <dfn>fallback chain</dfn>, which is a list
@@ -3015,7 +3015,7 @@
         mode/minimal-ui=]", "[=display mode/browser=]" ».
       </p>
       <p>
-        A user agent MUST reflect the applied <a>display mode</a> of the web
+        A user agent MUST reflect the <a>applied display mode</a> of the web
         application in the <a data-xref-type="css-descriptor" data-xref-for=
         "@media">`display-mode`</a> media feature [[MEDIAQUERIES-5]].
       </p>

--- a/index.html
+++ b/index.html
@@ -2938,12 +2938,11 @@
       </p>
       <p>
         Once a manifest is [=applied=] to a <a>top-level browsing context</a>,
-        the resulting <a>display mode</a> becomes the <dfn>applied display
-        mode</dfn> for that <a>top-level browsing context</a> (i.e., it is the
-        display mode used when the window is <a>navigated</a>). The user agent
-        MAY override the <a>applied display mode</a> for security reasons
-        (e.g., the <a>top-level browsing context</a> is <a>navigated</a> out
-        of scope) and/or the user agent MAY provide the user with a means of
+        the <a>display mode</a> in effect is the <dfn>applied display
+        mode</dfn> for that <a>top-level browsing context</a>. The user agent
+        MAY change the <a>applied display mode</a> for security reasons (e.g.,
+        the <a>top-level browsing context</a> is <a>navigated</a> out of
+        scope) and/or the user agent MAY provide the user with a means of
         switching to another <a>display mode</a>.
       </p>
       <p>
@@ -3020,7 +3019,7 @@
         "@media">`display-mode`</a> media feature [[MEDIAQUERIES-5]].
       </p>
       <p class="note">
-        A user agent will expose the actual display mode being applied — not
+        A user agent will expose the <a>applied display mode</a> — not
         necessarily the one declared in the manifest — via the
         <a data-xref-type="css-descriptor" data-xref-for=
         "@media">`display-mode`</a> media feature, accessible through CSS or

--- a/index.html
+++ b/index.html
@@ -2937,14 +2937,14 @@
         returns `false`.
       </p>
       <p>
-        Once a manifest is [=applied=] to an <a>application context</a>, the
-        resulting <a>display mode</a> becomes the <dfn>applied display
-        mode</dfn> for the <a>top-level browsing context</a> (i.e., it is
-        the display mode used when the window is <a>navigated</a>). The user
-        agent MAY override the <a>applied display mode</a> for security
-        reasons (e.g., the <a>top-level browsing context</a> is
-        <a>navigated</a> out of scope) and/or the user agent MAY provide the
-        user with a means of switching to another <a>display mode</a>.
+        Once a manifest is [=applied=] to a <a>top-level browsing context</a>,
+        the resulting <a>display mode</a> becomes the <dfn>applied display
+        mode</dfn> for that <a>top-level browsing context</a> (i.e., it is the
+        display mode used when the window is <a>navigated</a>). The user agent
+        MAY override the <a>applied display mode</a> for security reasons
+        (e.g., the <a>top-level browsing context</a> is <a>navigated</a> out
+        of scope) and/or the user agent MAY provide the user with a means of
+        switching to another <a>display mode</a>.
       </p>
       <p>
         When the [=manifest/display=] member is missing, or if there is no


### PR DESCRIPTION
Closes #1024

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

editorial: rename "default display mode" to "applied display mode"

The term "default" implied a fallback, when it actually meant the display mode
currently in effect. This rename clarifies the three roles: the manifest's
`display` member declares the preferred display mode, the UA determines the
applied display mode (via the fallback chain and user/UA overrides), and the
`display-mode` media feature reflects the applied one.

Also fixes the `[=applies=]` cross-reference so the subject is the manifest
(matching the dfn at #applying), and corrects the security override example
from "another origin" to "out of scope" for consistency with the rest of the
spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1215.html" title="Last updated on May 7, 2026, 11:53 AM UTC (65115ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1215/c0d4307...65115ec.html" title="Last updated on May 7, 2026, 11:53 AM UTC (65115ec)">Diff</a>