### PR TITLE
Add `application-context` CSS media feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -3079,6 +3079,184 @@
         data-xref-for="@media">`display-mode`</a> media feature.
       </p>
     </section>
+    <section id="installed-media-feature">
+      <h2>
+        Installed context: the `installed` media feature
+      </h2>
+      <p>
+        The <dfn id="mf-installed" data-dfn-type="css-descriptor" data-dfn-for=
+        "@media" class="export">`installed`</dfn> media feature reflects
+        whether the current [=browsing context=] is running as an [=installed
+        web application=].
+      </p>
+      <table class="data">
+        <thead>
+          <tr>
+            <th>
+              Value
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <dfn id="mf-installed-none" class="export" data-dfn-type="value"
+              data-dfn-for="@media/installed">none</dfn>
+            </td>
+            <td>
+              The document is not running as an [=installed web application=].
+              This is the value in a regular browser tab, inside an embedded
+              browser in a third-party application, or in any context where the
+              manifest is not [=applied=].
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn id="mf-installed-installed" class="export" data-dfn-type=
+              "value" data-dfn-for="@media/installed">installed</dfn>
+            </td>
+            <td>
+              The document is running as an [=installed web application=]. The
+              user agent launched the document from an operating system
+              integration surface (such as a home screen, dock, or taskbar) and
+              the document is running in an [=application context=].
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        The <a href="#mf-installed">`installed`</a> media feature matches
+        <a href="#mf-installed-installed">`installed`</a> when the [=browsing
+        context=] is an [=application context=] with a manifest [=applied=].
+        Otherwise, it matches <a href="#mf-installed-none">`none`</a>.
+      </p>
+      <p>
+        In cross-origin child [=browsing contexts=] (e.g., cross-origin iframes
+        and fenced frames), the value MUST be <a href=
+        "#mf-installed-none">`none`</a>, regardless of the value in the
+        [=top-level browsing context=].
+      </p>
+      <p class="note">
+        Same-origin child [=browsing contexts=] inherit the value from their
+        parent, since they can already access this information via
+        <code>window.top.matchMedia("(installed)")</code>.
+      </p>
+      <p>
+        The <a href="#mf-installed">`installed`</a> media feature is orthogonal
+        to the <a data-xref-type="css-descriptor" data-xref-for=
+        "@media">`display-mode`</a> media feature. An [=installed web
+        application=] can use any [=display mode=], including [=display
+        mode/fullscreen=], [=display mode/standalone=], [=display
+        mode/minimal-ui=], or [=display mode/browser=]. The <a href=
+        "#mf-installed">`installed`</a> media feature answers "is this document
+        running as an installed application?" while `display-mode` answers
+        "what presentation mode is the browsing context using?"
+      </p>
+      <p>
+        If the user agent transitions a [=browsing context=] into an
+        [=application context=] (for example, by [=applying=] a manifest after
+        the user [=installs=] the application while the document is already
+        open), the value of <a href="#mf-installed">`installed`</a> MUST update
+        accordingly and the user agent MUST [=fire an event=] named
+        <code>change</code> at the corresponding <code>MediaQueryList</code>.
+      </p>
+      <p>
+        The value of <a href="#mf-installed">`installed`</a> in a print context
+        MUST be <a href="#mf-installed-none">`none`</a>. Installation launch
+        context is not meaningful in print output.
+      </p>
+      <p class="note">
+        The <a href="#mf-installed">`installed`</a> media feature is designed
+        to be used in a boolean context. <code>@media (installed)</code>
+        evaluates to true when the value is <a href=
+        "#mf-installed-installed">`installed`</a> and false when the value is
+        <a href="#mf-installed-none">`none`</a>. The explicit form <code>@media
+        (installed: installed)</code> is valid but the idiomatic form is the
+        boolean shorthand <code>@media (installed)</code>.
+      </p>
+      <aside class="example">
+        <p>
+          Suppress install prompts when the app is already running as
+          installed:
+        </p>
+        <pre class="css">
+@media (installed) {
+  .install-banner { display: none; }
+}
+</pre>
+        <p>
+          Adapt UI for the installed app context:
+        </p>
+        <pre class="css">
+@media (installed) {
+  .browser-nav { display: none; }
+  .share-via-os { display: block; }
+}
+</pre>
+        <p>
+          JavaScript access via <code>matchMedia()</code>:
+        </p>
+        <pre class="js">
+const installed = window.matchMedia("(installed)").matches;
+if (installed) {
+  // Running as an installed app - suppress install UI
+  document.querySelector(".install-banner")?.remove();
+}
+</pre>
+      </aside>
+      <p class="note">
+        Conformance testing for the <a href=
+        "#mf-installed-installed">`installed`</a> value requires launching the
+        document from an OS integration surface, which may not be automatable
+        in all testing environments. User agents SHOULD provide a WebDriver
+        extension or testing mode that allows setting the <a href=
+        "#mf-installed">`installed`</a> value for conformance testing purposes.
+        The <a href="#mf-installed-none">`none`</a> value can be verified
+        automatically in any regular browsing context.
+      </p>
+      <section>
+        <h3>
+          Privacy considerations for the `installed` media feature
+        </h3>
+        <p>
+          The <a href="#mf-installed">`installed`</a> media feature exposes one
+          bit of information: whether the current document is running as an
+          [=installed web application=]. A document running in a regular
+          browser tab sees <a href="#mf-installed-none">`none`</a>, even if the
+          user previously [=installed=] the application on the same device.
+        </p>
+        <p>
+          The media feature does not reveal:
+        </p>
+        <ul>
+          <li>Whether the user has previously [=installed=] this or any other
+          web application.
+          </li>
+          <li>Any user history, preferences, or OS-level state.
+          </li>
+          <li>Whether this specific document meets any user-agent-specific
+          [=installation=] criteria.
+          </li>
+        </ul>
+        <p>
+          In cross-origin child [=browsing contexts=], the value is always
+          <a href="#mf-installed-none">`none`</a>, preventing cross-origin
+          iframes from learning the [=top-level browsing context=]'s
+          installation state.
+        </p>
+        <p>
+          As with all CSS media features, a document's own stylesheets may use
+          conditional <code>@import</code> rules or resource URLs within
+          <code>@media (installed)</code> blocks, causing network requests that
+          reveal the media feature's value to third-party servers. This is a
+          general property of the CSS media query mechanism and is not unique
+          to this feature.
+        </p>
+      </section>
+    </section>
     <section id="priv-sec">
       <h2>
         Privacy and security considerations

--- a/index.html
+++ b/index.html
@@ -3079,183 +3079,183 @@
         data-xref-for="@media">`display-mode`</a> media feature.
       </p>
     </section>
-    <section id="installed-media-feature">
-      <h2>
-        Installed context: the `installed` media feature
-      </h2>
+
+    <h2 id="installed-media-feature">
+      Installed context: the `installed` media feature
+    </h2>
+    <p>
+      The <dfn id="mf-installed" data-dfn-type="css-descriptor" data-dfn-for=
+      "@media" class="export">`installed`</dfn> media feature reflects whether
+      the current [=browsing context=]'s [=top-level browsing context=] is
+      running as an [=installed web application=].
+    </p>
+    <table class="data">
+      <thead>
+        <tr>
+          <th>
+            Value
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <dfn id="mf-installed-none" class="export" data-dfn-type="value"
+            data-dfn-for="@media/installed">none</dfn>
+          </td>
+          <td>
+            The document is not running as an [=installed web application=].
+            This is the value in a regular browser tab, inside an embedded
+            browser in a third-party application, or in any context where the
+            manifest is not [=applied=].
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn id="mf-installed-installed" class="export" data-dfn-type=
+            "value" data-dfn-for="@media/installed">installed</dfn>
+          </td>
+          <td>
+            The document is running as an [=installed web application=], in an
+            [=application context=], with a manifest [=applied=]. This can
+            occur regardless of how the user agent entered that application
+            context.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p>
+      The <a href="#mf-installed">`installed`</a> media feature matches
+      <a href="#mf-installed-installed">`installed`</a> when the
+      [=top-level browsing context=] of the current [=browsing context=] is an
+      [=application context=]. Otherwise, it matches <a href=
+      "#mf-installed-none">`none`</a>.
+    </p>
+    <p>
+      In cross-origin child [=browsing contexts=] (e.g., cross-origin iframes
+      and fenced frames), the value MUST be <a href=
+      "#mf-installed-none">`none`</a>, regardless of the value in the
+      [=top-level browsing context=].
+    </p>
+    <p class="note">
+      Same-origin child [=browsing contexts=] inherit the value from their
+      parent, since they can already access this information via
+      <code>window.parent.matchMedia("(installed)")</code>.
+    </p>
+    <p>
+      The <a href="#mf-installed">`installed`</a> media feature is orthogonal
+      to the <a data-xref-type="css-descriptor" data-xref-for=
+      "@media">`display-mode`</a> media feature. An [=installed web
+      application=] can use any [=display mode=], including [=display
+      mode/fullscreen=], [=display mode/standalone=], [=display
+      mode/minimal-ui=], or [=display mode/browser=]. The <a href=
+      "#mf-installed">`installed`</a> media feature answers "is this document
+      running as an installed application?" while `display-mode` answers "what
+      presentation mode is the browsing context using?"
+    </p>
+    <p>
+      If the user agent transitions a [=browsing context=] into an
+      [=application context=] (for example, by [=applying=] a manifest after
+      the user [=installs=] the application while the document is already
+      open), the value of <a href="#mf-installed">`installed`</a> MUST update
+      accordingly and the user agent MUST [=fire an event=] named
+      <code>change</code> at the corresponding <code>MediaQueryList</code>.
+    </p>
+    <p>
+      The value of <a href="#mf-installed">`installed`</a> in a print context
+      MUST be <a href="#mf-installed-none">`none`</a>. Installation launch
+      context is not meaningful in print output.
+    </p>
+    <p class="note">
+      The <a href="#mf-installed">`installed`</a> media feature is designed to
+      be used in a boolean context. <code>@media (installed)</code> evaluates
+      to true when the value is <a href=
+      "#mf-installed-installed">`installed`</a> and false when the value is
+      <a href="#mf-installed-none">`none`</a>. The explicit form <code>@media
+      (installed: installed)</code> is valid but the idiomatic form is the
+      boolean shorthand <code>@media (installed)</code>.
+    </p>
+    <aside class="example">
       <p>
-        The <dfn id="mf-installed" data-dfn-type="css-descriptor" data-dfn-for=
-        "@media" class="export">`installed`</dfn> media feature reflects
-        whether the current [=browsing context=] is running as an [=installed
-        web application=].
+        Suppress install prompts when the app is already running as installed:
       </p>
-      <table class="data">
-        <thead>
-          <tr>
-            <th>
-              Value
-            </th>
-            <th>
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <dfn id="mf-installed-none" class="export" data-dfn-type="value"
-              data-dfn-for="@media/installed">none</dfn>
-            </td>
-            <td>
-              The document is not running as an [=installed web application=].
-              This is the value in a regular browser tab, inside an embedded
-              browser in a third-party application, or in any context where the
-              manifest is not [=applied=].
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn id="mf-installed-installed" class="export" data-dfn-type=
-              "value" data-dfn-for="@media/installed">installed</dfn>
-            </td>
-            <td>
-              The document is running as an [=installed web application=]. The
-              user agent launched the document from an operating system
-              integration surface (such as a home screen, dock, or taskbar) and
-              the document is running in an [=application context=].
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <pre class="css">
+        @media (installed) {
+          .install-banner { display: none; }
+        }
+      </pre>
       <p>
-        The <a href="#mf-installed">`installed`</a> media feature matches
-        <a href="#mf-installed-installed">`installed`</a> when the [=browsing
-        context=] is an [=application context=] with a manifest [=applied=].
-        Otherwise, it matches <a href="#mf-installed-none">`none`</a>.
+        Adapt UI for the installed app context:
       </p>
+      <pre class="css">
+        @media (installed) {
+          .browser-nav { display: none; }
+          .share-via-os { display: block; }
+        }
+      </pre>
       <p>
-        In cross-origin child [=browsing contexts=] (e.g., cross-origin iframes
-        and fenced frames), the value MUST be <a href=
-        "#mf-installed-none">`none`</a>, regardless of the value in the
-        [=top-level browsing context=].
+        JavaScript access via <code>matchMedia()</code>:
       </p>
-      <p class="note">
-        Same-origin child [=browsing contexts=] inherit the value from their
-        parent, since they can already access this information via
-        <code>window.top.matchMedia("(installed)")</code>.
+      <pre class="js">
+        const installed = window.matchMedia("(installed)").matches;
+        if (installed) {
+          // Running as an installed app - suppress install UI
+          document.querySelector(".install-banner")?.remove();
+        }
+      </pre>
+    </aside>
+    <p class="note">
+      Conformance testing for the <a href=
+      "#mf-installed-installed">`installed`</a> value requires the document to
+      be running in an [=application context=] with a manifest [=applied=],
+      which may not be automatable in all testing environments. User agents
+      SHOULD provide a WebDriver extension or testing mode that allows setting
+      the <a href="#mf-installed">`installed`</a> value for conformance testing
+      purposes. The <a href="#mf-installed-none">`none`</a> value can be
+      verified automatically in any regular browsing context.
+    </p>
+    <section>
+      <h3>
+        Privacy considerations for the `installed` media feature
+      </h3>
+      <p>
+        The <a href="#mf-installed">`installed`</a> media feature exposes one
+        bit of information: whether the current document is running as an
+        [=installed web application=]. A document running in a regular browser
+        tab sees <a href="#mf-installed-none">`none`</a>, even if the user
+        previously [=installed=] the application on the same device.
       </p>
       <p>
-        The <a href="#mf-installed">`installed`</a> media feature is orthogonal
-        to the <a data-xref-type="css-descriptor" data-xref-for=
-        "@media">`display-mode`</a> media feature. An [=installed web
-        application=] can use any [=display mode=], including [=display
-        mode/fullscreen=], [=display mode/standalone=], [=display
-        mode/minimal-ui=], or [=display mode/browser=]. The <a href=
-        "#mf-installed">`installed`</a> media feature answers "is this document
-        running as an installed application?" while `display-mode` answers
-        "what presentation mode is the browsing context using?"
+        The media feature does not reveal:
+      </p>
+      <ul>
+        <li>Whether the user has previously [=installed=] this or any other web
+        application.
+        </li>
+        <li>Any user history, preferences, or OS-level state.
+        </li>
+        <li>Whether this specific document meets any user-agent-specific
+        [=installation=] criteria.
+        </li>
+      </ul>
+      <p>
+        In cross-origin child [=browsing contexts=], the value is always
+        <a href="#mf-installed-none">`none`</a>, preventing cross-origin
+        iframes from learning the [=top-level browsing context=]'s installation
+        state.
       </p>
       <p>
-        If the user agent transitions a [=browsing context=] into an
-        [=application context=] (for example, by [=applying=] a manifest after
-        the user [=installs=] the application while the document is already
-        open), the value of <a href="#mf-installed">`installed`</a> MUST update
-        accordingly and the user agent MUST [=fire an event=] named
-        <code>change</code> at the corresponding <code>MediaQueryList</code>.
+        As with all CSS media features, a document's own stylesheets may use
+        conditional <code>@import</code> rules or resource URLs within
+        <code>@media (installed)</code> blocks, causing network requests that
+        reveal the media feature's value to third-party servers. This is a
+        general property of the CSS media query mechanism and is not unique to
+        this feature.
       </p>
-      <p>
-        The value of <a href="#mf-installed">`installed`</a> in a print context
-        MUST be <a href="#mf-installed-none">`none`</a>. Installation launch
-        context is not meaningful in print output.
-      </p>
-      <p class="note">
-        The <a href="#mf-installed">`installed`</a> media feature is designed
-        to be used in a boolean context. <code>@media (installed)</code>
-        evaluates to true when the value is <a href=
-        "#mf-installed-installed">`installed`</a> and false when the value is
-        <a href="#mf-installed-none">`none`</a>. The explicit form <code>@media
-        (installed: installed)</code> is valid but the idiomatic form is the
-        boolean shorthand <code>@media (installed)</code>.
-      </p>
-      <aside class="example">
-        <p>
-          Suppress install prompts when the app is already running as
-          installed:
-        </p>
-        <pre class="css">
-@media (installed) {
-  .install-banner { display: none; }
-}
-</pre>
-        <p>
-          Adapt UI for the installed app context:
-        </p>
-        <pre class="css">
-@media (installed) {
-  .browser-nav { display: none; }
-  .share-via-os { display: block; }
-}
-</pre>
-        <p>
-          JavaScript access via <code>matchMedia()</code>:
-        </p>
-        <pre class="js">
-const installed = window.matchMedia("(installed)").matches;
-if (installed) {
-  // Running as an installed app - suppress install UI
-  document.querySelector(".install-banner")?.remove();
-}
-</pre>
-      </aside>
-      <p class="note">
-        Conformance testing for the <a href=
-        "#mf-installed-installed">`installed`</a> value requires launching the
-        document from an OS integration surface, which may not be automatable
-        in all testing environments. User agents SHOULD provide a WebDriver
-        extension or testing mode that allows setting the <a href=
-        "#mf-installed">`installed`</a> value for conformance testing purposes.
-        The <a href="#mf-installed-none">`none`</a> value can be verified
-        automatically in any regular browsing context.
-      </p>
-      <section>
-        <h3>
-          Privacy considerations for the `installed` media feature
-        </h3>
-        <p>
-          The <a href="#mf-installed">`installed`</a> media feature exposes one
-          bit of information: whether the current document is running as an
-          [=installed web application=]. A document running in a regular
-          browser tab sees <a href="#mf-installed-none">`none`</a>, even if the
-          user previously [=installed=] the application on the same device.
-        </p>
-        <p>
-          The media feature does not reveal:
-        </p>
-        <ul>
-          <li>Whether the user has previously [=installed=] this or any other
-          web application.
-          </li>
-          <li>Any user history, preferences, or OS-level state.
-          </li>
-          <li>Whether this specific document meets any user-agent-specific
-          [=installation=] criteria.
-          </li>
-        </ul>
-        <p>
-          In cross-origin child [=browsing contexts=], the value is always
-          <a href="#mf-installed-none">`none`</a>, preventing cross-origin
-          iframes from learning the [=top-level browsing context=]'s
-          installation state.
-        </p>
-        <p>
-          As with all CSS media features, a document's own stylesheets may use
-          conditional <code>@import</code> rules or resource URLs within
-          <code>@media (installed)</code> blocks, causing network requests that
-          reveal the media feature's value to third-party servers. This is a
-          general property of the CSS media query mechanism and is not unique
-          to this feature.
-        </p>
-      </section>
+
     </section>
     <section id="priv-sec">
       <h2>

--- a/index.html
+++ b/index.html
@@ -3079,7 +3079,6 @@
         data-xref-for="@media">`display-mode`</a> media feature.
       </p>
     </section>
-
     <h2 id="installed-media-feature">
       Installed context: the `installed` media feature
     </h2>
@@ -3129,8 +3128,8 @@
     </table>
     <p>
       The <a href="#mf-installed">`installed`</a> media feature matches
-      <a href="#mf-installed-installed">`installed`</a> when the
-      [=top-level browsing context=] of the current [=browsing context=] is an
+      <a href="#mf-installed-installed">`installed`</a> when the [=top-level
+      browsing context=] of the current [=browsing context=] is an
       [=application context=]. Otherwise, it matches <a href=
       "#mf-installed-none">`none`</a>.
     </p>
@@ -3143,7 +3142,7 @@
     <p class="note">
       Same-origin child [=browsing contexts=] inherit the value from their
       parent, since they can already access this information via
-      <code>window.parent.matchMedia("(installed)")</code>.
+      `window.parent.matchMedia("(installed)")`.
     </p>
     <p>
       The <a href="#mf-installed">`installed`</a> media feature is orthogonal
@@ -3156,13 +3155,13 @@
       running as an installed application?" while `display-mode` answers "what
       presentation mode is the browsing context using?"
     </p>
-    <p>
+    <p data-cite="CSSOM-VIEW-1">
       If the user agent transitions a [=browsing context=] into an
       [=application context=] (for example, by [=applying=] a manifest after
       the user [=installs=] the application while the document is already
       open), the value of <a href="#mf-installed">`installed`</a> MUST update
-      accordingly and the user agent MUST [=fire an event=] named
-      <code>change</code> at the corresponding <code>MediaQueryList</code>.
+      accordingly and the user agent MUST [=fire an event=] named `change` at
+      the corresponding {{MediaQueryList}}.
     </p>
     <p>
       The value of <a href="#mf-installed">`installed`</a> in a print context
@@ -3171,12 +3170,11 @@
     </p>
     <p class="note">
       The <a href="#mf-installed">`installed`</a> media feature is designed to
-      be used in a boolean context. <code>@media (installed)</code> evaluates
-      to true when the value is <a href=
-      "#mf-installed-installed">`installed`</a> and false when the value is
-      <a href="#mf-installed-none">`none`</a>. The explicit form <code>@media
-      (installed: installed)</code> is valid but the idiomatic form is the
-      boolean shorthand <code>@media (installed)</code>.
+      be used in a boolean context. `@media (installed)` evaluates to true when
+      the value is <a href="#mf-installed-installed">`installed`</a> and false
+      when the value is <a href="#mf-installed-none">`none`</a>. The explicit
+      form `@media (installed: installed)` is valid but the idiomatic form is
+      the boolean shorthand `@media (installed)`.
     </p>
     <aside class="example">
       <p>
@@ -3197,7 +3195,7 @@
         }
       </pre>
       <p>
-        JavaScript access via <code>matchMedia()</code>:
+        JavaScript access via `matchMedia()`:
       </p>
       <pre class="js">
         const installed = window.matchMedia("(installed)").matches;
@@ -3249,13 +3247,11 @@
       </p>
       <p>
         As with all CSS media features, a document's own stylesheets may use
-        conditional <code>@import</code> rules or resource URLs within
-        <code>@media (installed)</code> blocks, causing network requests that
-        reveal the media feature's value to third-party servers. This is a
-        general property of the CSS media query mechanism and is not unique to
-        this feature.
+        conditional `@import` rules or resource URLs within `@media
+        (installed)` blocks, causing network requests that reveal the media
+        feature's value to third-party servers. This is a general property of
+        the CSS media query mechanism and is not unique to this feature.
       </p>
-
     </section>
     <section id="priv-sec">
       <h2>

--- a/index.html
+++ b/index.html
@@ -3147,21 +3147,19 @@
     <p>
       The value of <a data-link-for="@media">application-context</a> MUST be
       <a data-link-for="@media/application-context">none</a> in a [=document=]
-      whose [=Document/origin=] is not [=same origin=] with its [=node
-      navigable=]'s [=navigable/top-level traversable=]'s [=navigable/active
-      document=]'s [=Document/origin=].
-    </p>
-    <p>
-      In a [=child navigable=] whose [=navigable/active document=] is [=same
-      origin=] with its [=navigable/top-level traversable=]'s
-      [=navigable/active document=], the value of <a data-link-for=
-      "@media">application-context</a> MUST be the same as the value for the
-      [=navigable/top-level traversable=]'s [=navigable/active document=].
+      unless the [=document=] is [=same origin=] with the [=navigable/active
+      document=] of each of its [=Document/ancestor navigables=]. That is, a
+      [=document=] only observes the [=application context=] when it and every
+      one of its ancestors up to the [=top-level traversable=] are [=same
+      origin=].
     </p>
     <aside class="note" title="Same-origin access">
       <p>
-        This is consistent with same-origin script's existing access via
-        `window.top.matchMedia("(application-context: application)")`.
+        A [=document=] that observes the [=application context=] is [=same
+        origin=] with all of its ancestors, and so can already reach its
+        [=top-level traversable=]'s [=navigable/active document=] via
+        `window.top` (e.g., `window.top.matchMedia("(application-context:
+        application)")`).
       </p>
     </aside>
     <p data-cite="CSSOM-VIEW-1">
@@ -3226,9 +3224,9 @@
         cases where the <a data-xref-type="css-descriptor" data-xref-for=
         "@media">`display-mode`</a> media feature does not distinguish it, such
         as fullscreen. In other cases, the [=display mode/standalone=] and
-        [=display mode/minimal-ui=] display modes already reveal the application
-        context. This feature makes the signal explicit and reliable across
-        display modes.
+        [=display mode/minimal-ui=] display modes already reveal the
+        application context. This feature makes the signal explicit and
+        reliable across display modes.
       </p>
     </aside>
     <p>
@@ -3243,17 +3241,30 @@
       <li>Whether the page meets any user-agent-specific [=installation=]
       criteria.
       </li>
-      <li>The installation state of an embedding [=installed web application=]
-      to a cross-origin embedded context. The normative requirement above
-      ensures that any cross-origin nested [=document=] sees <a href=
-      "#mf-application-context-none">`none`</a> regardless of its embedder's
-      state.
+      <li>The application context to a [=document=] that is not [=same origin=]
+      with all of its ancestors up to the [=top-level traversable=]. Per the
+      normative requirement above, any such [=document=] evaluates to
+      <a data-link-for="@media/application-context">none</a>, so a cross-origin
+      embedded context, or any [=document=] nested within one, cannot observe
+      the [=application context=].
       </li>
     </ul>
+    <aside class="note" title="Evaluated across the full ancestor chain">
+      <p>
+        A [=document=] observes the [=application context=] only when it and
+        every one of its ancestors up to the [=top-level traversable=] are
+        [=same origin=]. A [=document=] nested inside a cross-origin ancestor
+        evaluates to <a data-link-for="@media/application-context">none</a>
+        even if it is itself [=same origin=] with the [=top-level
+        traversable=]'s [=navigable/active document=]. This is stricter than a
+        check against the top-level [=document=] alone, and prevents a
+        cross-origin embedder from observing the [=application context=]
+        through a same-origin descendant it hosts.
+      </p>
+    </aside>
     <p>
-      However, as with any CSS media feature, the value of <a href=
-      "#mf-application-context">`application-context`</a> can be inferred
-      through:
+      However, as with any CSS media feature, the value of <a data-link-for=
+      "@media">application-context</a> can be inferred through:
     </p>
     <ul>
       <li>Conditional `@import` rules or resource URLs within `@media

--- a/index.html
+++ b/index.html
@@ -3113,12 +3113,16 @@
       [=navigable/top-level traversable=]'s [=navigable/active document=]'s
       [=Document/origin=].
     </p>
+    <p>
+      In a [=child navigable=] whose [=navigable/active document=] is [=same
+      origin=] with its [=navigable/top-level traversable=]'s
+      [=navigable/active document=], the value of <a href=
+      "#mf-installed">`installed`</a> MUST be the same as the value for the
+      [=navigable/top-level traversable=]'s [=navigable/active document=].
+    </p>
     <p class="note">
-      In a [=child navigable=] that is [=same origin=] with its
-      [=navigable/top-level traversable=]'s [=navigable/active document=],
-      <a href="#mf-installed">`installed`</a> reflects the same value as the
-      [=navigable/top-level traversable=], since same-origin script can already
-      observe it via `window.top.matchMedia("(installed)")`.
+      This is consistent with same-origin script's existing access via
+      `window.top.matchMedia("(installed)")`.
     </p>
     <p class="note">
       The <a href="#mf-installed">`installed`</a> media feature is designed to
@@ -3127,6 +3131,14 @@
       value is <a href="#mf-installed-none">`none`</a>. The explicit form
       `@media (installed: installed)` is valid but the boolean shorthand
       `@media (installed)` is the idiomatic form.
+    </p>
+    <p class="note">
+      This specification defines two values for <a href=
+      "#mf-installed">`installed`</a>. Future specifications adding new values
+      should ensure that any new value either semantically denotes an installed
+      launch context (and thus matches `@media (installed)` in boolean context)
+      or evaluates as `false` in boolean context, so that content authored
+      against this version of the specification continues to work as intended.
     </p>
     <p class="note">
       The <a href="#mf-installed">`installed`</a> media feature is orthogonal
@@ -3212,11 +3224,22 @@
       </li>
     </ul>
     <p>
-      As with all CSS media features, a document's own stylesheets may use
-      conditional `@import` rules or resource URLs within `@media (installed)`
-      blocks, causing network requests that reveal the media feature's value to
-      third-party servers. This is a general property of the CSS media query
-      mechanism and is not unique to this feature.
+      However, as with any CSS media feature, the value of <a href=
+      "#mf-installed">`installed`</a> can be inferred through:
+    </p>
+    <ul>
+      <li>Conditional `@import` rules or resource URLs within `@media
+      (installed)` blocks, where the resulting network requests reveal the
+      media feature's value to third-party servers.
+      </li>
+      <li>The timing of transitions between values (for example, during install
+      or uninstall flows), observable to same-origin script via the `change`
+      event on `MediaQueryList`.
+      </li>
+    </ul>
+    <p class="note">
+      These are intrinsic properties of the CSS media query mechanism and are
+      not unique to this feature.
     </p>
     <section id="priv-sec">
       <h2>

--- a/index.html
+++ b/index.html
@@ -3220,16 +3220,15 @@
       "@media/application-context">none</a>, even if the user previously
       [=installed=] the application on the same device.
     </p>
-    <aside class="note" title="Not a new information exposure">
+    <aside class="note" title="Information exposure">
       <p>
-        This media feature does not expose information that authors could not
-        already infer. The <a data-xref-type="css-descriptor" data-xref-for=
-        "@media">`display-mode`</a> media feature already reveals the
-        application context most of the time, since the [=display
-        mode/standalone=] and [=display mode/minimal-ui=] display modes only
-        occur within an [=application context=]. This feature makes that signal
-        explicit and reliable, rather than something authors reconstruct
-        imperfectly from `display-mode`.
+        This media feature makes the application context directly observable in
+        cases where the <a data-xref-type="css-descriptor" data-xref-for=
+        "@media">`display-mode`</a> media feature does not distinguish it, such
+        as fullscreen. In other cases, the [=display mode/standalone=] and
+        [=display mode/minimal-ui=] display modes already reveal the application
+        context. This feature makes the signal explicit and reliable across
+        display modes.
       </p>
     </aside>
     <p>

--- a/index.html
+++ b/index.html
@@ -3080,105 +3080,80 @@
       </p>
     </section>
     <h2 id="installed-media-feature">
-      Installed context: the `installed` media feature
+      The `installed` media feature
     </h2>
     <p>
       The <dfn id="mf-installed" data-dfn-type="css-descriptor" data-dfn-for=
       "@media" class="export">`installed`</dfn> media feature reflects whether
-      the current [=browsing context=]'s [=top-level browsing context=] is
-      running as an [=installed web application=].
+      the [=document=]'s [=top-level browsing context=] is an [=application
+      context=]. It takes one of the following values:
     </p>
-    <table class="data">
-      <thead>
-        <tr>
-          <th>
-            Value
-          </th>
-          <th>
-            Description
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            <dfn id="mf-installed-none" class="export" data-dfn-type="value"
-            data-dfn-for="@media/installed">none</dfn>
-          </td>
-          <td>
-            The document is not running as an [=installed web application=].
-            This is the value in a regular browser tab, inside an embedded
-            browser in a third-party application, or in any context where the
-            manifest is not [=applied=].
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <dfn id="mf-installed-installed" class="export" data-dfn-type=
-            "value" data-dfn-for="@media/installed">installed</dfn>
-          </td>
-          <td>
-            The document is running as an [=installed web application=], in an
-            [=application context=], with a manifest [=applied=]. This can
-            occur regardless of how the user agent entered that application
-            context.
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <dl>
+      <dt>
+        <dfn id="mf-installed-installed" class="export" data-dfn-type="value"
+        data-dfn-for="@media/installed">installed</dfn>
+      </dt>
+      <dd>
+        The [=document=]'s [=top-level browsing context=] is an [=application
+        context=].
+      </dd>
+      <dt>
+        <dfn id="mf-installed-none" class="export" data-dfn-type="value"
+        data-dfn-for="@media/installed">none</dfn> (default)
+      </dt>
+      <dd>
+        Otherwise.
+      </dd>
+    </dl>
     <p>
-      The <a href="#mf-installed">`installed`</a> media feature matches
-      <a href="#mf-installed-installed">`installed`</a> when the [=top-level
-      browsing context=] of the current [=browsing context=] is an
-      [=application context=]. Otherwise, it matches <a href=
-      "#mf-installed-none">`none`</a>.
-    </p>
-    <p>
-      In cross-origin child [=browsing contexts=] (e.g., cross-origin iframes
-      and fenced frames), the value MUST be <a href=
-      "#mf-installed-none">`none`</a>, regardless of the value in the
-      [=top-level browsing context=].
+      The value of <a href="#mf-installed">`installed`</a> MUST be <a href=
+      "#mf-installed-none">`none`</a> in a [=document=] whose
+      [=Document/origin=] is not [=same origin=] with its [=node navigable=]'s
+      [=navigable/top-level traversable=]'s [=navigable/active document=]'s
+      [=Document/origin=].
     </p>
     <p class="note">
-      Same-origin child [=browsing contexts=] inherit the value from their
-      parent, since they can already access this information via
-      `window.parent.matchMedia("(installed)")`.
+      In a [=child navigable=] that is [=same origin=] with its
+      [=navigable/top-level traversable=]'s [=navigable/active document=],
+      <a href="#mf-installed">`installed`</a> reflects the same value as the
+      [=navigable/top-level traversable=], since same-origin script can already
+      observe it via `window.top.matchMedia("(installed)")`.
     </p>
-    <p>
+    <p class="note">
+      The <a href="#mf-installed">`installed`</a> media feature is designed to
+      be used in a boolean context. `@media (installed)` is true when the value
+      is <a href="#mf-installed-installed">`installed`</a> and false when the
+      value is <a href="#mf-installed-none">`none`</a>. The explicit form
+      `@media (installed: installed)` is valid but the boolean shorthand
+      `@media (installed)` is the idiomatic form.
+    </p>
+    <p class="note">
       The <a href="#mf-installed">`installed`</a> media feature is orthogonal
       to the <a data-xref-type="css-descriptor" data-xref-for=
       "@media">`display-mode`</a> media feature. An [=installed web
       application=] can use any [=display mode=], including [=display
       mode/fullscreen=], [=display mode/standalone=], [=display
       mode/minimal-ui=], or [=display mode/browser=]. The <a href=
-      "#mf-installed">`installed`</a> media feature answers "is this document
-      running as an installed application?" while `display-mode` answers "what
-      presentation mode is the browsing context using?"
+      "#mf-installed">`installed`</a> media feature answers "is this an
+      installed application?" while `display-mode` answers "what presentation
+      mode is being used?"
     </p>
     <p data-cite="CSSOM-VIEW-1">
-      If the user agent transitions a [=browsing context=] into an
-      [=application context=] (for example, by [=applying=] a manifest after
-      the user [=installs=] the application while the document is already
-      open), the value of <a href="#mf-installed">`installed`</a> MUST update
-      accordingly and the user agent MUST [=fire an event=] named `change` at
-      the corresponding {{MediaQueryList}}.
+      When a [=top-level browsing context=] becomes, or ceases to be, an
+      [=application context=], for each [=document=] in that context the user
+      agent MUST run the steps to [=evaluate media queries and report changes=]
+      for that [=document=].
     </p>
     <p>
-      The value of <a href="#mf-installed">`installed`</a> in a print context
-      MUST be <a href="#mf-installed-none">`none`</a>. Installation launch
-      context is not meaningful in print output.
-    </p>
-    <p class="note">
-      The <a href="#mf-installed">`installed`</a> media feature is designed to
-      be used in a boolean context. `@media (installed)` evaluates to true when
-      the value is <a href="#mf-installed-installed">`installed`</a> and false
-      when the value is <a href="#mf-installed-none">`none`</a>. The explicit
-      form `@media (installed: installed)` is valid but the idiomatic form is
-      the boolean shorthand `@media (installed)`.
+      The value of <a href="#mf-installed">`installed`</a> MUST be <a href=
+      "#mf-installed-none">`none`</a> when the document is not being rendered
+      for the `screen` media type (for example, in a `print` or `speech`
+      context). Installation launch context is not meaningful outside `screen`
+      rendering.
     </p>
     <aside class="example">
       <p>
-        Suppress install prompts when the app is already running as installed:
+        Hide install prompts when the app is already running as installed:
       </p>
       <pre class="css">
         @media (installed) {
@@ -3200,59 +3175,46 @@
       <pre class="js">
         const installed = window.matchMedia("(installed)").matches;
         if (installed) {
-          // Running as an installed app - suppress install UI
+          // Running as an installed app - hide install UI
           document.querySelector(".install-banner")?.remove();
         }
       </pre>
     </aside>
-    <p class="note">
-      Conformance testing for the <a href=
-      "#mf-installed-installed">`installed`</a> value requires the document to
-      be running in an [=application context=] with a manifest [=applied=],
-      which may not be automatable in all testing environments. User agents
-      SHOULD provide a WebDriver extension or testing mode that allows setting
-      the <a href="#mf-installed">`installed`</a> value for conformance testing
-      purposes. The <a href="#mf-installed-none">`none`</a> value can be
-      verified automatically in any regular browsing context.
+    <h3>
+      Privacy considerations for the `installed` media feature
+    </h3>
+    <p>
+      The <a href="#mf-installed">`installed`</a> media feature exposes one bit
+      of information: whether the [=document=]'s [=top-level browsing context=]
+      is an [=application context=]. In a regular browser tab, the value is
+      <a href="#mf-installed-none">`none`</a>, even if the user previously
+      [=installed=] the application on the same device.
     </p>
-    <section>
-      <h3>
-        Privacy considerations for the `installed` media feature
-      </h3>
-      <p>
-        The <a href="#mf-installed">`installed`</a> media feature exposes one
-        bit of information: whether the current document is running as an
-        [=installed web application=]. A document running in a regular browser
-        tab sees <a href="#mf-installed-none">`none`</a>, even if the user
-        previously [=installed=] the application on the same device.
-      </p>
-      <p>
-        The media feature does not reveal:
-      </p>
-      <ul>
-        <li>Whether the user has previously [=installed=] this or any other web
-        application.
-        </li>
-        <li>Any user history, preferences, or OS-level state.
-        </li>
-        <li>Whether this specific document meets any user-agent-specific
-        [=installation=] criteria.
-        </li>
-      </ul>
-      <p>
-        In cross-origin child [=browsing contexts=], the value is always
-        <a href="#mf-installed-none">`none`</a>, preventing cross-origin
-        iframes from learning the [=top-level browsing context=]'s installation
-        state.
-      </p>
-      <p>
-        As with all CSS media features, a document's own stylesheets may use
-        conditional `@import` rules or resource URLs within `@media
-        (installed)` blocks, causing network requests that reveal the media
-        feature's value to third-party servers. This is a general property of
-        the CSS media query mechanism and is not unique to this feature.
-      </p>
-    </section>
+    <p>
+      The media feature <strong>does not</strong> reveal:
+    </p>
+    <ul>
+      <li>Whether the user has previously [=installed=] this or any other web
+      application.
+      </li>
+      <li>Any user history, preferences, or OS-level state.
+      </li>
+      <li>Whether the page meets any user-agent-specific [=installation=]
+      criteria.
+      </li>
+      <li>The installation state of an embedding [=installed web application=]
+      to a cross-origin embedded context. The normative requirement above
+      ensures that any cross-origin nested [=document=] sees <a href=
+      "#mf-installed-none">`none`</a> regardless of its embedder's state.
+      </li>
+    </ul>
+    <p>
+      As with all CSS media features, a document's own stylesheets may use
+      conditional `@import` rules or resource URLs within `@media (installed)`
+      blocks, causing network requests that reveal the media feature's value to
+      third-party servers. This is a general property of the CSS media query
+      mechanism and is not unique to this feature.
+    </p>
     <section id="priv-sec">
       <h2>
         Privacy and security considerations

--- a/index.html
+++ b/index.html
@@ -3085,8 +3085,9 @@
     <p>
       The <dfn id="mf-installed" data-dfn-type="css-descriptor" data-dfn-for=
       "@media" class="export">`installed`</dfn> media feature reflects whether
-      the [=document=]'s [=top-level browsing context=] is an [=application
-      context=]. It takes one of the following values:
+      the [=document=]'s [=node navigable=]'s [=navigable/top-level
+      traversable=] is an [=application context=]. It takes one of the
+      following values:
     </p>
     <dl>
       <dt>
@@ -3094,8 +3095,8 @@
         data-dfn-for="@media/installed">installed</dfn>
       </dt>
       <dd>
-        The [=document=]'s [=top-level browsing context=] is an [=application
-        context=].
+        The [=document=]'s [=node navigable=]'s [=navigable/top-level
+        traversable=] is an [=application context=].
       </dd>
       <dt>
         <dfn id="mf-installed-none" class="export" data-dfn-type="value"
@@ -3139,10 +3140,11 @@
       mode is being used?"
     </p>
     <p data-cite="CSSOM-VIEW-1">
-      When a [=top-level browsing context=] becomes, or ceases to be, an
-      [=application context=], for each [=document=] in that context the user
-      agent MUST run the steps to [=evaluate media queries and report changes=]
-      for that [=document=].
+      When a [=top-level traversable=] becomes, or ceases to be, an
+      [=application context=], the user agent MUST run the steps to [=evaluate
+      media queries and report changes=] for each [=document=] whose [=node
+      navigable=]'s [=navigable/top-level traversable=] is that [=top-level
+      traversable=].
     </p>
     <p>
       The value of <a href="#mf-installed">`installed`</a> MUST be <a href=
@@ -3185,9 +3187,10 @@
     </h3>
     <p>
       The <a href="#mf-installed">`installed`</a> media feature exposes one bit
-      of information: whether the [=document=]'s [=top-level browsing context=]
-      is an [=application context=]. In a regular browser tab, the value is
-      <a href="#mf-installed-none">`none`</a>, even if the user previously
+      of information: whether the [=document=]'s [=node navigable=]'s
+      [=navigable/top-level traversable=] is an [=application context=]. In a
+      regular browser tab, the value is <a href=
+      "#mf-installed-none">`none`</a>, even if the user previously
       [=installed=] the application on the same device.
     </p>
     <p>

--- a/index.html
+++ b/index.html
@@ -3107,29 +3107,29 @@
         application=] can use any [=display mode=], including [=display
         mode/fullscreen=], [=display mode/standalone=], [=display
         mode/minimal-ui=], or [=display mode/browser=]. The <a data-link-for=
-        "@media">application-context</a> media feature answers "what
-        application context is this running in?" while `display-mode` answers
-        "what presentation mode is being used?"
+        "@media">application-context</a> media feature answers "what context is
+        this running in?" while `display-mode` answers "what presentation mode
+        is being used?"
       </p>
     </aside>
     <p>
-      The <a data-link-for="@media">application-context</a> media feature
-      takes one of the following values:
+      The <a data-link-for="@media">application-context</a> media feature takes
+      one of the following values:
     </p>
     <dl>
       <dt>
-        <code><dfn id="mf-application-context-installed" class="export"
+        <code><dfn id="mf-application-context-application" class="export"
         data-dfn-type="value" data-dfn-for=
-        "@media/application-context">installed</dfn></code>
+        "@media/application-context">application</dfn></code>
       </dt>
       <dd>
         The [=document=]'s [=node navigable=]'s [=navigable/top-level
         traversable=] is an [=application context=].
       </dd>
       <dt>
-        <code><dfn id="mf-application-context-browser" class="export"
+        <code><dfn id="mf-application-context-none" class="export"
         data-dfn-type="value" data-dfn-for=
-        "@media/application-context">browser</dfn></code> (default)
+        "@media/application-context">none</dfn></code> (default)
       </dt>
       <dd>
         Otherwise.
@@ -3142,15 +3142,15 @@
         values to describe additional application contexts. Content authored
         against this version of the specification should continue to identify
         [=installed web application=] contexts using `(application-context:
-        installed)`.
+        application)`.
       </p>
     </aside>
     <p>
       The value of <a data-link-for="@media">application-context</a> MUST be
-      <a data-link-for="@media/application-context">browser</a> in a
-      [=document=] whose [=Document/origin=] is not [=same origin=] with its
-      [=node navigable=]'s [=navigable/top-level traversable=]'s
-      [=navigable/active document=]'s [=Document/origin=].
+      <a data-link-for="@media/application-context">none</a> in a [=document=]
+      whose [=Document/origin=] is not [=same origin=] with its [=node
+      navigable=]'s [=navigable/top-level traversable=]'s [=navigable/active
+      document=]'s [=Document/origin=].
     </p>
     <p>
       In a [=child navigable=] whose [=navigable/active document=] is [=same
@@ -3162,7 +3162,7 @@
     <aside class="note" title="Same-origin access">
       <p>
         This is consistent with same-origin script's existing access via
-        `window.top.matchMedia("(application-context: installed)")`.
+        `window.top.matchMedia("(application-context: application)")`.
       </p>
     </aside>
     <p data-cite="CSSOM-VIEW-1">
@@ -3174,9 +3174,9 @@
     </p>
     <p>
       The value of <a data-link-for="@media">application-context</a> MUST be
-      <a data-link-for="@media/application-context">browser</a> when the
-      document is not being rendered for the `screen` media type (for example,
-      in a `print` or `speech` context). Application context is not meaningful
+      <a data-link-for="@media/application-context">none</a> when the document
+      is not being rendered for the `screen` media type (for example, in a
+      `print` or `speech` context). Application context is not meaningful
       outside `screen` rendering.
     </p>
     <aside class="example">
@@ -3184,7 +3184,7 @@
         Hide install prompts when the app is already running as installed:
       </p>
       <pre class="css">
-        @media (application-context: installed) {
+        @media (application-context: application) {
           .install-banner { display: none; }
         }
       </pre>
@@ -3192,7 +3192,7 @@
         Adapt UI for the installed app context:
       </p>
       <pre class="css">
-        @media (application-context: installed) {
+        @media (application-context: application) {
           .browser-nav { display: none; }
           .share-via-os { display: block; }
         }
@@ -3201,10 +3201,10 @@
         JavaScript access via `matchMedia()`:
       </p>
       <pre class="js">
-        const installed = window.matchMedia(
-          "(application-context: installed)"
+        const inAppContext = window.matchMedia(
+          "(application-context: application)"
         ).matches;
-        if (installed) {
+        if (inAppContext) {
           // Running as an installed app - hide install UI
           document.querySelector(".install-banner")?.remove();
         }
@@ -3218,9 +3218,21 @@
       exposes one bit of information: whether the [=document=]'s [=node
       navigable=]'s [=navigable/top-level traversable=] is an [=application
       context=]. In a regular browser tab, the value is <a data-link-for=
-      "@media/application-context">browser</a>, even if the user previously
+      "@media/application-context">none</a>, even if the user previously
       [=installed=] the application on the same device.
     </p>
+    <aside class="note" title="Not a new information exposure">
+      <p>
+        This media feature does not expose information that authors could not
+        already infer. The <a data-xref-type="css-descriptor" data-xref-for=
+        "@media">`display-mode`</a> media feature already reveals the
+        application context most of the time, since the [=display
+        mode/standalone=] and [=display mode/minimal-ui=] display modes only
+        occur within an [=application context=]. This feature makes that signal
+        explicit and reliable, rather than something authors reconstruct
+        imperfectly from `display-mode`.
+      </p>
+    </aside>
     <p>
       The media feature <strong>does not</strong> reveal:
     </p>
@@ -3236,8 +3248,8 @@
       <li>The installation state of an embedding [=installed web application=]
       to a cross-origin embedded context. The normative requirement above
       ensures that any cross-origin nested [=document=] sees <a href=
-      "#mf-application-context-browser">`browser`</a> regardless of its
-      embedder's state.
+      "#mf-application-context-none">`none`</a> regardless of its embedder's
+      state.
       </li>
     </ul>
     <p>
@@ -3247,7 +3259,7 @@
     </p>
     <ul>
       <li>Conditional `@import` rules or resource URLs within `@media
-      (application-context: installed)` blocks, where the resulting network
+      (application-context: application)` blocks, where the resulting network
       requests reveal the media feature's value to third-party servers.
       </li>
       <li>The timing of transitions between values (for example, during install

--- a/index.html
+++ b/index.html
@@ -3079,77 +3079,71 @@
         data-xref-for="@media">`display-mode`</a> media feature.
       </p>
     </section>
-    <h2 id="installed-media-feature">
-      The `installed` media feature
+    <h2 id="application-context-media-feature">
+      The `application-context` media feature
     </h2>
     <p>
-      The <dfn id="mf-installed" data-dfn-type="css-descriptor" data-dfn-for=
-      "@media" class="export">`installed`</dfn> media feature reflects whether
-      the [=document=]'s [=node navigable=]'s [=navigable/top-level
-      traversable=] is an [=application context=]. It takes one of the
-      following values:
+      The <code><dfn id="mf-application-context" data-dfn-type="css-descriptor"
+      data-dfn-for="@media" class="export">application-context</dfn></code>
+      media feature reflects the application context in which the
+      [=document=]'s [=node navigable=]'s [=navigable/top-level traversable=]
+      is running. It takes one of the following values:
     </p>
     <dl>
       <dt>
-        <dfn id="mf-installed-installed" class="export" data-dfn-type="value"
-        data-dfn-for="@media/installed">installed</dfn>
+        <code><dfn id="mf-application-context-installed" class="export"
+        data-dfn-type="value" data-dfn-for=
+        "@media/application-context">installed</dfn></code>
       </dt>
       <dd>
         The [=document=]'s [=node navigable=]'s [=navigable/top-level
         traversable=] is an [=application context=].
       </dd>
       <dt>
-        <dfn id="mf-installed-none" class="export" data-dfn-type="value"
-        data-dfn-for="@media/installed">none</dfn> (default)
+        <code><dfn id="mf-application-context-browser" class="export"
+        data-dfn-type="value" data-dfn-for=
+        "@media/application-context">browser</dfn></code> (default)
       </dt>
       <dd>
         Otherwise.
       </dd>
     </dl>
     <p>
-      The value of <a href="#mf-installed">`installed`</a> MUST be <a href=
-      "#mf-installed-none">`none`</a> in a [=document=] whose
-      [=Document/origin=] is not [=same origin=] with its [=node navigable=]'s
-      [=navigable/top-level traversable=]'s [=navigable/active document=]'s
-      [=Document/origin=].
+      The value of <a data-link-for="@media">application-context</a> MUST be
+      <a data-link-for="@media/application-context">browser</a> in a
+      [=document=] whose [=Document/origin=] is not [=same origin=] with its
+      [=node navigable=]'s [=navigable/top-level traversable=]'s
+      [=navigable/active document=]'s [=Document/origin=].
     </p>
     <p>
       In a [=child navigable=] whose [=navigable/active document=] is [=same
       origin=] with its [=navigable/top-level traversable=]'s
-      [=navigable/active document=], the value of <a href=
-      "#mf-installed">`installed`</a> MUST be the same as the value for the
+      [=navigable/active document=], the value of <a data-link-for=
+      "@media">application-context</a> MUST be the same as the value for the
       [=navigable/top-level traversable=]'s [=navigable/active document=].
     </p>
     <p class="note">
       This is consistent with same-origin script's existing access via
-      `window.top.matchMedia("(installed)")`.
+      `window.top.matchMedia("(application-context: installed)")`.
     </p>
     <p class="note">
-      The <a href="#mf-installed">`installed`</a> media feature is designed to
-      be used in a boolean context. `@media (installed)` is true when the value
-      is <a href="#mf-installed-installed">`installed`</a> and false when the
-      value is <a href="#mf-installed-none">`none`</a>. The explicit form
-      `@media (installed: installed)` is valid but the boolean shorthand
-      `@media (installed)` is the idiomatic form.
+      This specification defines two values for <a data-link-for=
+      "@media">application-context</a>. Future specifications may add new
+      values to describe additional application contexts. Content authored
+      against this version of the specification should continue to identify
+      [=installed web application=] contexts using `(application-context:
+      installed)`.
     </p>
     <p class="note">
-      This specification defines two values for <a href=
-      "#mf-installed">`installed`</a>. Future specifications adding new values
-      should ensure that any new value either semantically denotes an installed
-      launch context (and thus matches `@media (installed)` in boolean context)
-      or evaluates as `false` in boolean context, so that content authored
-      against this version of the specification continues to work as intended.
-    </p>
-    <p class="note">
-      The <a href="#mf-installed">`installed`</a> media feature is orthogonal
-      to the <a data-xref-type="css-descriptor" data-xref-for=
+      The <a data-link-for="@media">application-context</a> media feature is
+      orthogonal to the <a data-xref-type="css-descriptor" data-xref-for=
       "@media">`display-mode`</a> media feature. An [=installed web
       application=] can use any [=display mode=], including [=display
       mode/fullscreen=], [=display mode/standalone=], [=display
-      mode/minimal-ui=], or [=display mode/browser=]. The <a href=
-      "#mf-installed">`installed`</a> media feature answers "is this an
-      installed application?" while `display-mode` answers "what presentation
-      mode is being used?"
+      mode/minimal-ui=], or [=display mode/browser=]. The <a data-link-for=
+      "@media">application-context</a> media feature answers "what application
+      context is this running in?" while `display-mode` answers "what
+      presentation mode is being used?"
     </p>
     <p data-cite="CSSOM-VIEW-1">
       When a [=top-level traversable=] becomes, or ceases to be, an
@@ -3159,18 +3153,18 @@
       traversable=].
     </p>
     <p>
-      The value of <a href="#mf-installed">`installed`</a> MUST be <a href=
-      "#mf-installed-none">`none`</a> when the document is not being rendered
-      for the `screen` media type (for example, in a `print` or `speech`
-      context). Installation launch context is not meaningful outside `screen`
-      rendering.
+      The value of <a data-link-for="@media">application-context</a> MUST be
+      <a data-link-for="@media/application-context">browser</a> when the
+      document is not being rendered for the `screen` media type (for example,
+      in a `print` or `speech` context). Application context is not meaningful
+      outside `screen` rendering.
     </p>
     <aside class="example">
       <p>
         Hide install prompts when the app is already running as installed:
       </p>
       <pre class="css">
-        @media (installed) {
+        @media (application-context: installed) {
           .install-banner { display: none; }
         }
       </pre>
@@ -3178,7 +3172,7 @@
         Adapt UI for the installed app context:
       </p>
       <pre class="css">
-        @media (installed) {
+        @media (application-context: installed) {
           .browser-nav { display: none; }
           .share-via-os { display: block; }
         }
@@ -3187,7 +3181,9 @@
         JavaScript access via `matchMedia()`:
       </p>
       <pre class="js">
-        const installed = window.matchMedia("(installed)").matches;
+        const installed = window.matchMedia(
+          "(application-context: installed)"
+        ).matches;
         if (installed) {
           // Running as an installed app - hide install UI
           document.querySelector(".install-banner")?.remove();
@@ -3195,14 +3191,14 @@
       </pre>
     </aside>
     <h3>
-      Privacy considerations for the `installed` media feature
+      Privacy considerations for the `application-context` media feature
     </h3>
     <p>
-      The <a href="#mf-installed">`installed`</a> media feature exposes one bit
-      of information: whether the [=document=]'s [=node navigable=]'s
-      [=navigable/top-level traversable=] is an [=application context=]. In a
-      regular browser tab, the value is <a href=
-      "#mf-installed-none">`none`</a>, even if the user previously
+      The <a data-link-for="@media">application-context</a> media feature
+      exposes one bit of information: whether the [=document=]'s [=node
+      navigable=]'s [=navigable/top-level traversable=] is an [=application
+      context=]. In a regular browser tab, the value is <a data-link-for=
+      "@media/application-context">browser</a>, even if the user previously
       [=installed=] the application on the same device.
     </p>
     <p>
@@ -3220,17 +3216,19 @@
       <li>The installation state of an embedding [=installed web application=]
       to a cross-origin embedded context. The normative requirement above
       ensures that any cross-origin nested [=document=] sees <a href=
-      "#mf-installed-none">`none`</a> regardless of its embedder's state.
+      "#mf-application-context-browser">`browser`</a> regardless of its
+      embedder's state.
       </li>
     </ul>
     <p>
       However, as with any CSS media feature, the value of <a href=
-      "#mf-installed">`installed`</a> can be inferred through:
+      "#mf-application-context">`application-context`</a> can be inferred
+      through:
     </p>
     <ul>
       <li>Conditional `@import` rules or resource URLs within `@media
-      (installed)` blocks, where the resulting network requests reveal the
-      media feature's value to third-party servers.
+      (application-context: installed)` blocks, where the resulting network
+      requests reveal the media feature's value to third-party servers.
       </li>
       <li>The timing of transitions between values (for example, during install
       or uninstall flows), observable to same-origin script via the `change`

--- a/index.html
+++ b/index.html
@@ -3112,8 +3112,8 @@
       </p>
     </aside>
     <p>
-      The <a data-link-for="@media">application-context</a> media feature takes
-      one of the following values:
+      The <a data-link-for="@media">application-context</a> media feature is a
+      discrete media feature that takes one of the following values:
     </p>
     <dl>
       <dt>

--- a/index.html
+++ b/index.html
@@ -3087,7 +3087,24 @@
       data-dfn-for="@media" class="export">application-context</dfn></code>
       media feature reflects the application context in which the
       [=document=]'s [=node navigable=]'s [=navigable/top-level traversable=]
-      is running. It takes one of the following values:
+      is running.
+    </p>
+    <aside class="note" title="Independent of `display-mode`">
+      <p>
+        The <a data-link-for="@media">application-context</a> media feature is
+        orthogonal to the <a data-xref-type="css-descriptor" data-xref-for=
+        "@media">`display-mode`</a> media feature. An [=installed web
+        application=] can use any [=display mode=], including [=display
+        mode/fullscreen=], [=display mode/standalone=], [=display
+        mode/minimal-ui=], or [=display mode/browser=]. The <a data-link-for=
+        "@media">application-context</a> media feature answers "what
+        application context is this running in?" while `display-mode` answers
+        "what presentation mode is being used?"
+      </p>
+    </aside>
+    <p>
+      The <a data-link-for="@media">application-context</a> media feature
+      takes one of the following values:
     </p>
     <dl>
       <dt>
@@ -3108,6 +3125,16 @@
         Otherwise.
       </dd>
     </dl>
+    <aside class="note" title="Extensibility">
+      <p>
+        This specification defines two values for <a data-link-for=
+        "@media">application-context</a>. Future specifications may add new
+        values to describe additional application contexts. Content authored
+        against this version of the specification should continue to identify
+        [=installed web application=] contexts using `(application-context:
+        installed)`.
+      </p>
+    </aside>
     <p>
       The value of <a data-link-for="@media">application-context</a> MUST be
       <a data-link-for="@media/application-context">browser</a> in a
@@ -3122,29 +3149,12 @@
       "@media">application-context</a> MUST be the same as the value for the
       [=navigable/top-level traversable=]'s [=navigable/active document=].
     </p>
-    <p class="note">
-      This is consistent with same-origin script's existing access via
-      `window.top.matchMedia("(application-context: installed)")`.
-    </p>
-    <p class="note">
-      This specification defines two values for <a data-link-for=
-      "@media">application-context</a>. Future specifications may add new
-      values to describe additional application contexts. Content authored
-      against this version of the specification should continue to identify
-      [=installed web application=] contexts using `(application-context:
-      installed)`.
-    </p>
-    <p class="note">
-      The <a data-link-for="@media">application-context</a> media feature is
-      orthogonal to the <a data-xref-type="css-descriptor" data-xref-for=
-      "@media">`display-mode`</a> media feature. An [=installed web
-      application=] can use any [=display mode=], including [=display
-      mode/fullscreen=], [=display mode/standalone=], [=display
-      mode/minimal-ui=], or [=display mode/browser=]. The <a data-link-for=
-      "@media">application-context</a> media feature answers "what application
-      context is this running in?" while `display-mode` answers "what
-      presentation mode is being used?"
-    </p>
+    <aside class="note" title="Same-origin access">
+      <p>
+        This is consistent with same-origin script's existing access via
+        `window.top.matchMedia("(application-context: installed)")`.
+      </p>
+    </aside>
     <p data-cite="CSSOM-VIEW-1">
       When a [=top-level traversable=] becomes, or ceases to be, an
       [=application context=], the user agent MUST run the steps to [=evaluate


### PR DESCRIPTION
Closes #1092

Adds the `application-context` CSS media feature, a discrete media feature that reflects the application context in which the current top-level traversable is running. Values are `application` and `none` (default). Same-origin iframes inherit the parent value; cross-origin iframes evaluate to `none`. The value can transition from `none` to `application` when the user agent promotes a browsing context into an installed application window.

Aligned with Microsoft's [Application Context Media Feature](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ApplicationContextMediaFeature/explainer.md) explainer. Agreed in principle at TPAC 2025 (#1092). Values renamed from `installed`/`browser` to `application`/`none` per working group discussion, to remove the ambiguity between installation lifecycle state and the current running context.

This change (choose at least one, delete ones that don't apply):

* Adds new normative requirements

Implementation commitment (delete if not making normative changes):

* [ ] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=314609)
* [ ] [Chromium](https://crbug.com/382114911)
* [ ] Gecko (http://bugzilla.mozilla.org)

Commit message:

Add the `application-context` CSS media feature

Documents can query `(application-context: application)` to detect whether the current top-level traversable is running as an installed web application; the value is `none` in a regular browser tab and in cross-origin nested documents.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1218.html" title="Last updated on Sep 10, 2026, 3:56 PM UTC (65bb071)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1218/8ae3046...65bb071.html" title="Last updated on Sep 10, 2026, 3:56 PM UTC (65bb071)">Diff</a>