### PR TITLE
chore: fix SchemaStore links and drop the embedded schema view

### DIFF
--- a/index.html
+++ b/index.html
@@ -3564,9 +3564,9 @@
       </h2>
       <p>
         Developers interested in validating <a>manifest</a> documents can find
-        an unofficial <a href="https://json.schemastore.org/web-manifest">JSON
+        an unofficial <a href="https://www.schemastore.org/web-manifest">JSON
         schema for the manifest format</a> at <a href=
-        "https://schemastore.org/json/">schemastore.org</a>. It is licensed
+        "https://www.schemastore.org/">schemastore.org</a>. It is licensed
         under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache
         2.0</a>. It is kindly maintained by <a href=
         "https://github.com/madskristensen">Mads Kristensen</a>. If developers
@@ -3575,15 +3575,6 @@
         the <a href="https://github.com/SchemaStore/schemastore">SchemaStore
         repository</a> on GitHub.
       </p>
-      <aside class="note" title="Web Manifest JSON Schema">
-        <details>
-          <summary>
-            Click to view schema.
-          </summary>
-          <pre class="json" data-include=
-          "https://json.schemastore.org/web-manifest"></pre>
-        </details>
-      </aside>
     </section>
     <section id="internationalization" class="appendix informative" data-cite=
     "i18n-glossary">


### PR DESCRIPTION
This change (choose at least one, delete ones that don't apply):

* Is a "chore" (metadata, formatting, fixing warnings, etc).

Commit message:

chore: fix SchemaStore links and drop the embedded schema view

The embedded JSON schema in the appendix has not been rendering — the "Click to view schema" block is empty, also in the published TR snapshot. `json.schemastore.org/web-manifest` 301-redirects to `www.schemastore.org/web-manifest`, and the redirect response carries no CORS headers, so ReSpec's `data-include` fetch fails (`data-include failed: … (Failed to fetch)`).

This PR points the schema link at the canonical host, points the `schemastore.org/json/` link at the homepage (the `/json/` path 404s), and removes the broken embedded schema note altogether. The reference to the schema on schemastore.org remains.

(Even with the URL fixed, the embedded view would stay empty due to a ReSpec quirk: its highlighter reads `innerText`, which is empty inside a closed `<details>`, wiping the included content — one more reason to just link instead of embedding.)

No normative changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1220.html" title="Last updated on Jul 23, 2026, 10:18 PM UTC (ca1c3a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1220/2244970...ca1c3a3.html" title="Last updated on Jul 23, 2026, 10:18 PM UTC (ca1c3a3)">Diff</a>