### PR TITLE
Recommend user agents let users inspect and modify shortcut URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3162,7 +3162,13 @@
         developers could encode strings into the [=shortcut item/url=] that
         uniquely identify the user (e.g., a server assigned <abbr>UUID</abbr>).
         This is fingerprinting/privacy sensitive information that the user
-        might not be aware of.
+        might not be aware of, and, like an identifier encoded into the [=start
+        URL=], it is not cleared when the user clears site data.
+      </p>
+      <p>
+        As with the [=start URL=], it is RECOMMENDED that a user agent allows
+        the user to inspect and, if necessary, modify the [=shortcut item/url=]
+        of a shortcut, upon installation or any time thereafter.
       </p>
       <p>
         When the web application is running, it is RECOMMENDED that the user

--- a/index.html
+++ b/index.html
@@ -3178,7 +3178,7 @@
       <p>
         As with the [=start URL=], it is RECOMMENDED that a user agent allows
         the user to inspect and, if necessary, modify the [=shortcut item/url=]
-        of a shortcut, upon installation or any time thereafter.
+        of a shortcut, upon installation, or any time thereafter.
       </p>
       <p>
         When the web application is running, it is RECOMMENDED that the user


### PR DESCRIPTION
Shortcut URLs can encode a user-identifying string that, like an identifier in the start URL, is not cleared when the user clears site data. This adds that note for shortcuts and mirrors the existing start_url tracking mitigation by recommending user agents let the user inspect and, if necessary, modify a shortcut's URL. Surfaced while completing the Security and Privacy self-review for CR.

Adds new normative recommendations or optional items.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1221.html" title="Last updated on Jul 23, 2026, 10:21 PM UTC (89a0ad7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1221/af03eb3...89a0ad7.html" title="Last updated on Jul 23, 2026, 10:21 PM UTC (89a0ad7)">Diff</a>