### PR TITLE
Internationalization -> Internationalization Considerations, clarifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -2821,13 +2821,13 @@
         </li>
         <li>Let |scopePath:string| be the [=string/concatenation=] of
         |scopes|'s [=URL/path=] using <span class="codepoint" translate=
-        "no"><bdi lang="en">/</bdi><code class="uname">U+002F SOLIDUS</code></span>
-        as the separator.
+        "no"><bdi lang="en">/</bdi><code class="uname">U+002F
+        SOLIDUS</code></span> as the separator.
         </li>
         <li>Let |targetPath:string| be the [=string/concatenation=] of
         |target|'s [=URL/path=] using <span class="codepoint" translate=
-        "no"><bdi lang="en">/</bdi><code class="uname">U+002F SOLIDUS</code></span>
-        as the separator.
+        "no"><bdi lang="en">/</bdi><code class="uname">U+002F
+        SOLIDUS</code></span> as the separator.
         </li>
         <li>Return a [=boolean=] indicating whether |targetPath| starts with
         |scopePath:string|.
@@ -3598,7 +3598,7 @@
     <section id="internationalization" class="appendix informative" data-cite=
     "i18n-glossary">
       <h2>
-        Internationalization
+        Internationalization Considerations
       </h2>
       <p>
         It is expected that authors will localize the content of a manifest by
@@ -3609,11 +3609,46 @@
           Localized values in the manifest:
         </dt>
         <dd>
-          Authors can provide [=localized values=] for the [=localizable
-          members=] of the [=manifest=]. The user agent passes all localized
-          values to the host operating system. When the user changes the
-          [=locale=] at the OS level, the OS can present the updated localized
-          values of the [=installed web application=].
+          <p>
+            Authors can provide [=localized values=] for the [=localizable
+            members=] of the [=manifest=] using the corresponding `*_localized`
+            members (e.g., `name_localized`). Individual localized entries can
+            be a [=string=] or a [=localized text object=]. A [=localized text
+            object=] can specify its own natural language and text-direction
+            metadata using its [=manifest/*_localized/lang=] and
+            [=manifest/*_localized/dir=] properties, overriding any defaults
+            provided by the manifest-wide [=manifest/lang=] and
+            [=manifest/dir=] members.
+          </p>
+          <p>
+            User agents MAY handle localized values in one of the following
+            ways:
+          </p>
+          <dl>
+            <dt>
+              Pass-through localization:
+            </dt>
+            <dd>
+              The user agent passes all localized values (the entire language
+              map) to the host operating system during installation. When the
+              user changes their preferred language at the OS level, the host
+              OS can immediately present the updated localized values (e.g.,
+              the application name) without requiring the user agent to run.
+            </dd>
+            <dt>
+              On-demand/update evaluation:
+            </dt>
+            <dd>
+              The user agent evaluates the localized values at parse time based
+              on the user's current locale. When the user changes the system
+              language, the app properties do not update immediately. Instead,
+              they are updated when the user next visits the application or
+              during a background update check, allowing the user agent to
+              inspect and potentially request user acknowledgment for
+              security-sensitive changes (such as a name change) before
+              updating the host OS.
+            </dd>
+          </dl>
         </dd>
         <dt>
           Dynamically setting the language:
@@ -3625,14 +3660,20 @@
           preference (e.g., using a URL like "manifest.php?lang=fr").
         </dd>
         <dt>
-          Using content-negotiation, or geotargeting, etc. on the server:
+          Using server-side language negotiation or geotargeting:
         </dt>
         <dd>
           The server that hosts the web application could attempt to
           predetermine the end-user's language by using <a href=
           "https://en.wikipedia.org/wiki/Geotargeting">geotargeting</a> or by
-          using content negotiation (e.g., using an HTTP "`Accept-Language`"
-          header [[RFC9110]], or even a custom HTTP header).
+          performing [=language negotiation=] (e.g., via the HTTP
+          "`Accept-Language`" header [[RFC9110]], or a custom HTTP header). For
+          more details and best practices, see the W3C Internationalization
+          articles <a href=
+          "https://www.w3.org/International/questions/qa-accept-lang-locales">Accept-Language
+          used for locale setting</a> and <a href=
+          "https://www.w3.org/International/questions/qa-http-and-lang">HTTP
+          headers, meta elements and language information</a>.
         </dd>
       </dl>
       <p>


### PR DESCRIPTION
Closes #1232

This change:
* [x] Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)
* [x] Is a "chore" (metadata, formatting, fixing warnings, etc).

**Commit message:**
```
editorial: Formalize Internationalization appendix as Internationalization Considerations and clarify UA localization options
```

**Description:**
This PR addresses feedback from the horizontal internationalization review:
- Rename the appendix to "Internationalization Considerations" as preferred by the spec guidelines.
- Link directly to the spec definitions for `localized text object`, `lang`, and `dir` properties of `*_localized` members.
- Present the two main ways user agents handle localized values (pass-through localization vs. on-demand/update-time evaluation), clarifying that UAs have flexibility in implementation (e.g. Chrome's behavior of verifying name changes at update time).
- Link to relevant W3C i18n articles on language negotiation rather than reproducing their content.
- Ran HTML `tidy` to format the modified section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dmurph/manifest/pull/1234.html" title="Last updated on Jul 23, 2026, 11:07 PM UTC (a7fdc67)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1234/b74c08a...dmurph:a7fdc67.html" title="Last updated on Jul 23, 2026, 11:07 PM UTC (a7fdc67)">Diff</a>