### PR TITLE
Format U+002F character references using W3C I18N template

### DIFF
--- a/index.html
+++ b/index.html
@@ -2821,10 +2821,14 @@
         <li>If |target| and |scope| are not [=same origin=], return `false`.
         </li>
         <li>Let |scopePath:string| be the [=string/concatenation=] of
-        |scopes|'s [=URL/path=] using U+002F (/) as the separator.
+        |scopes|'s [=URL/path=] using <span class="codepoint" translate=
+        "no"><bdi lang="en">/</bdi><code class="uname">U+002F SOLIDUS</code></span>
+        as the separator.
         </li>
         <li>Let |targetPath:string| be the [=string/concatenation=] of
-        |target|'s [=URL/path=] using U+002F (/) as the separator.
+        |target|'s [=URL/path=] using <span class="codepoint" translate=
+        "no"><bdi lang="en">/</bdi><code class="uname">U+002F SOLIDUS</code></span>
+        as the separator.
         </li>
         <li>Return a [=boolean=] indicating whether |targetPath| starts with
         |scopePath:string|.


### PR DESCRIPTION
Closes #1231

This change (choose at least one, delete ones that don't apply):

* [x] Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

editorial: Format U+002F character references using W3C I18N template

Update the U+002F character references in the "within scope" section to use standard W3C I18N template markup.

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* editorial:


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dmurph/manifest/pull/1235.html" title="Last updated on Jul 23, 2026, 11:00 PM UTC (94116d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1235/3faa601...dmurph:94116d4.html" title="Last updated on Jul 23, 2026, 11:00 PM UTC (94116d4)">Diff</a>