### PR TITLE
Editorial: don't reference WebIDL identifier

### DIFF
--- a/index.html
+++ b/index.html
@@ -1076,7 +1076,7 @@
           <p>
             Since [=manifest/id=] is resolved against [=manifest/start_url=]'s
             [=URL/origin=], providing "../foo", "foo", "/foo", "./foo" all
-            resolves to the same [=identifier=]. As such, best practice is to
+            resolves to the same identifier. As such, best practice is to
             use a leading "/" to be explicit that the id is a root-relative URL
             path. Also, standard encoding/decoding rules apply to the id
             processing algorithm, as per the [[[URL]]].


### PR DESCRIPTION
This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/pull/1237.html" title="Last updated on Aug 13, 2026, 5:33 PM UTC (b63f312)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1237/4b21a78...b63f312.html" title="Last updated on Aug 13, 2026, 5:33 PM UTC (b63f312)">Diff</a>