### PR TITLE
editorial: add missing assertion to chosen-display-mode algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -3052,6 +3052,8 @@
             </li>
           </ol>
         </li>
+        <li>Assert: this step is never reached.
+        </li>
       </ol>
       <p class="note">
         The above loop is guaranteed to return a value before the assertion,


### PR DESCRIPTION
Closes #1055

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

editorial: add missing assertion to chosen-display-mode algorithm

The note under "steps for determining the web app's chosen display mode" says the loop "is guaranteed to return a value before the assertion", but the algorithm had no assertion. This adds the final "Assert: this step is never reached." step the note refers to. No behavioural change.

Person merging, please make sure that commits are squashed with the `editorial:` commit message prefix.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/manifest/pull/1238.html" title="Last updated on Jul 24, 2026, 1:50 AM UTC (3b19491)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/manifest/1238/76294d8...marcoscaceres:3b19491.html" title="Last updated on Jul 24, 2026, 1:50 AM UTC (3b19491)">Diff</a>